### PR TITLE
[feat]: add DynamoDB Messages table with GSI to HermesStorageStack (#4)

### DIFF
--- a/infra/lib/hermes-storage-stack.ts
+++ b/infra/lib/hermes-storage-stack.ts
@@ -6,6 +6,7 @@ import { Construct } from 'constructs';
 export class HermesStorageStack extends cdk.Stack {
   public readonly emailBucket: s3.Bucket;
   public readonly addressesTable: dynamodb.Table;
+  public readonly messagesTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -31,6 +32,19 @@ export class HermesStorageStack extends cdk.Stack {
       partitionKey: { name: 'email', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.messagesTable = new dynamodb.Table(this, 'MessagesTable', {
+      tableName: 'Messages',
+      partitionKey: { name: 'messageId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.messagesTable.addGlobalSecondaryIndex({
+      indexName: 'address-receivedAt-index',
+      partitionKey: { name: 'address', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'receivedAt', type: dynamodb.AttributeType.STRING },
     });
   }
 }

--- a/infra/test/hermes-storage-stack.test.ts
+++ b/infra/test/hermes-storage-stack.test.ts
@@ -85,4 +85,44 @@ describe('HermesStorageStack', () => {
       });
     });
   });
+
+  describe('Messages table', () => {
+    test('creates Messages DynamoDB table with correct PK', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'Messages',
+        KeySchema: [
+          { AttributeName: 'messageId', KeyType: 'HASH' },
+        ],
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'messageId', AttributeType: 'S' },
+        ]),
+      });
+    });
+
+    test('Messages table uses PAY_PER_REQUEST billing', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'Messages',
+        BillingMode: 'PAY_PER_REQUEST',
+      });
+    });
+
+    test('Messages table has address-receivedAt-index GSI', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'Messages',
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: 'address-receivedAt-index',
+            KeySchema: [
+              { AttributeName: 'address', KeyType: 'HASH' },
+              { AttributeName: 'receivedAt', KeyType: 'RANGE' },
+            ],
+          }),
+        ]),
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'address', AttributeType: 'S' },
+          { AttributeName: 'receivedAt', AttributeType: 'S' },
+        ]),
+      });
+    });
+  });
 });


### PR DESCRIPTION
- PK: messageId (String)
- GSI: address-receivedAt-index (PK: address, SK: receivedAt)
- Billing mode: PAY_PER_REQUEST
- 3 unit tests added and passing

closes #4