### PR TITLE
[feat]: add DynamoDB WsConnections table with TTL to HermesStorageSta…

### DIFF
--- a/infra/lib/hermes-storage-stack.ts
+++ b/infra/lib/hermes-storage-stack.ts
@@ -10,6 +10,7 @@ export class HermesStorageStack extends cdk.Stack {
   public readonly addressesTable: dynamodb.Table;
   public readonly messagesTable: dynamodb.Table;
   public readonly draftsTable: dynamodb.Table;
+  public readonly wsConnectionsTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
@@ -59,5 +60,14 @@ export class HermesStorageStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
     cdk.Tags.of(this.draftsTable).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    this.wsConnectionsTable = new dynamodb.Table(this, 'WsConnectionsTable', {
+      tableName: 'hermes-ws-connections',
+      partitionKey: { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'ttl',
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    cdk.Tags.of(this.wsConnectionsTable).add(HERMES_TAG.key, HERMES_TAG.value);
   }
 }

--- a/infra/test/hermes-storage-stack.test.ts
+++ b/infra/test/hermes-storage-stack.test.ts
@@ -173,4 +173,42 @@ describe('HermesStorageStack', () => {
       });
     });
   });
+
+  describe('WsConnections table', () => {
+    test('creates hermes-ws-connections DynamoDB table with correct PK', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'hermes-ws-connections',
+        KeySchema: [
+          { AttributeName: 'connectionId', KeyType: 'HASH' },
+        ],
+        AttributeDefinitions: Match.arrayWith([
+          { AttributeName: 'connectionId', AttributeType: 'S' },
+        ]),
+      });
+    });
+
+    test('hermes-ws-connections table uses PAY_PER_REQUEST billing', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'hermes-ws-connections',
+        BillingMode: 'PAY_PER_REQUEST',
+      });
+    });
+
+    test('hermes-ws-connections table has TTL enabled on ttl attribute', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'hermes-ws-connections',
+        TimeToLiveSpecification: {
+          AttributeName: 'ttl',
+          Enabled: true,
+        },
+      });
+    });
+
+    test('hermes-ws-connections table is tagged with Project=hermes', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'hermes-ws-connections',
+        Tags: Match.arrayWith([{ Key: 'Project', Value: 'hermes' }]),
+      });
+    });
+  });
 });


### PR DESCRIPTION
…ck (#6)

- Table name: hermes-ws-connections
- PK: connectionId (String)
- TTL enabled on ttl attribute
- Billing mode: PAY_PER_REQUEST
- Tagged Project=hermes
- 4 unit tests added and passing

closes #6