### PR TITLE
[feat]: add HermesEmailStack with SES receipt rule set (#7)

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib/core';
 import { HermesStorageStack } from '../lib/hermes-storage-stack';
+import { HermesEmailStack } from '../lib/hermes-email-stack';
 
 const app = new cdk.App();
 
-new HermesStorageStack(app, 'HermesStorageStack', {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
+const env = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: process.env.CDK_DEFAULT_REGION,
+};
+
+const storageStack = new HermesStorageStack(app, 'HermesStorageStack', { env });
+
+new HermesEmailStack(app, 'HermesEmailStack', {
+  env,
+  emailBucketArn: storageStack.emailBucket.bucketArn,
 });

--- a/infra/lib/hermes-email-stack.ts
+++ b/infra/lib/hermes-email-stack.ts
@@ -1,0 +1,30 @@
+import * as cdk from 'aws-cdk-lib/core';
+import * as ses from 'aws-cdk-lib/aws-ses';
+import { Construct } from 'constructs';
+
+const HERMES_TAG = { key: 'Project', value: 'hermes' };
+
+export interface HermesEmailStackProps extends cdk.StackProps {
+  emailBucketArn: string;
+}
+
+export class HermesEmailStack extends cdk.Stack {
+  public readonly receiptRuleSet: ses.CfnReceiptRuleSet;
+
+  constructor(scope: Construct, id: string, props: HermesEmailStackProps) {
+    super(scope, id, props);
+
+    this.receiptRuleSet = new ses.CfnReceiptRuleSet(this, 'ReceiptRuleSet', {
+      ruleSetName: 'hermes-receipt-rules',
+    });
+
+    new cdk.CfnResource(this, 'ActiveReceiptRuleSet', {
+      type: 'AWS::SES::ReceiptActiveRuleSet',
+      properties: {
+        RuleSetName: this.receiptRuleSet.ruleSetName!,
+      },
+    });
+
+    cdk.Tags.of(this.receiptRuleSet).add(HERMES_TAG.key, HERMES_TAG.value);
+  }
+}

--- a/infra/test/hermes-email-stack.test.ts
+++ b/infra/test/hermes-email-stack.test.ts
@@ -1,0 +1,36 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { HermesEmailStack } from '../lib/hermes-email-stack';
+
+const MOCK_BUCKET_ARN = 'arn:aws:s3:::hermes-email-store';
+
+describe('HermesEmailStack', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const app = new cdk.App();
+    const stack = new HermesEmailStack(app, 'TestHermesEmailStack', {
+      emailBucketArn: MOCK_BUCKET_ARN,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  describe('SES receipt rule set', () => {
+    test('creates receipt rule set named hermes-receipt-rules', () => {
+      template.hasResourceProperties('AWS::SES::ReceiptRuleSet', {
+        RuleSetName: 'hermes-receipt-rules',
+      });
+    });
+
+    test('sets hermes-receipt-rules as the active rule set', () => {
+      template.resourceCountIs('AWS::SES::ReceiptRuleSet', 1);
+      template.hasResourceProperties('AWS::SES::ReceiptActiveRuleSet', {
+        RuleSetName: 'hermes-receipt-rules',
+      });
+    });
+
+    test('no hardcoded per-address receipt rules in CDK', () => {
+      template.resourceCountIs('AWS::SES::ReceiptRule', 0);
+    });
+  });
+});


### PR DESCRIPTION
- New HermesEmailStack created
- SES receipt rule set hermes-receipt-rules created and set as active
- No hardcoded per-address rules (added dynamically via API)
- Tagged Project=hermes
- 3 unit tests added and passing

closes #7