### PR TITLE
[feat]: add SES to S3 IAM role for inbound delivery to HermesEmailSta…

### DIFF
--- a/infra/lib/hermes-email-stack.ts
+++ b/infra/lib/hermes-email-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib/core';
 import * as ses from 'aws-cdk-lib/aws-ses';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
 const HERMES_TAG = { key: 'Project', value: 'hermes' };
@@ -10,6 +11,7 @@ export interface HermesEmailStackProps extends cdk.StackProps {
 
 export class HermesEmailStack extends cdk.Stack {
   public readonly receiptRuleSet: ses.CfnReceiptRuleSet;
+  public readonly sesS3DeliveryRole: iam.Role;
 
   constructor(scope: Construct, id: string, props: HermesEmailStackProps) {
     super(scope, id, props);
@@ -26,5 +28,19 @@ export class HermesEmailStack extends cdk.Stack {
     });
 
     cdk.Tags.of(this.receiptRuleSet).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    this.sesS3DeliveryRole = new iam.Role(this, 'SesS3DeliveryRole', {
+      roleName: 'hermes-ses-s3-delivery',
+      assumedBy: new iam.ServicePrincipal('ses.amazonaws.com'),
+      description: 'Allows SES to deliver inbound email to the hermes-email-store S3 bucket',
+    });
+
+    this.sesS3DeliveryRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AllowSesInboundDelivery',
+      actions: ['s3:PutObject'],
+      resources: [`${props.emailBucketArn}/inbound/*`],
+    }));
+
+    cdk.Tags.of(this.sesS3DeliveryRole).add(HERMES_TAG.key, HERMES_TAG.value);
   }
 }

--- a/infra/test/hermes-email-stack.test.ts
+++ b/infra/test/hermes-email-stack.test.ts
@@ -33,4 +33,42 @@ describe('HermesEmailStack', () => {
       template.resourceCountIs('AWS::SES::ReceiptRule', 0);
     });
   });
+
+  describe('SES to S3 delivery role', () => {
+    test('creates IAM role trusted by ses.amazonaws.com', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: 'hermes-ses-s3-delivery',
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'sts:AssumeRole',
+              Principal: { Service: 'ses.amazonaws.com' },
+              Effect: 'Allow',
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('role policy grants s3:PutObject scoped to inbound/ prefix only', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 's3:PutObject',
+              Effect: 'Allow',
+              Resource: `${MOCK_BUCKET_ARN}/inbound/*`,
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('role is tagged with Project=hermes', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: 'hermes-ses-s3-delivery',
+        Tags: Match.arrayWith([{ Key: 'Project', Value: 'hermes' }]),
+      });
+    });
+  });
 });


### PR DESCRIPTION
…ck (#8)

- IAM role hermes-ses-s3-delivery trusted by ses.amazonaws.com
- s3:PutObject permission scoped to inbound/ prefix of hermes-email-store
- Tagged Project=hermes
- 3 unit tests added and passing

closes #8