### PR TITLE
[feat]: add CDK API Gateway WebSocket API with connect/disconnect han…

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!lambda/**/*.js
 *.d.ts
 node_modules
 

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -2,6 +2,7 @@
 import * as cdk from 'aws-cdk-lib/core';
 import { HermesStorageStack } from '../lib/hermes-storage-stack';
 import { HermesEmailStack } from '../lib/hermes-email-stack';
+import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
 
 const app = new cdk.App();
 
@@ -11,6 +12,11 @@ const env = {
 };
 
 const storageStack = new HermesStorageStack(app, 'HermesStorageStack', { env });
+
+const webSocketStack = new HermesWebSocketStack(app, 'HermesWebSocketStack', {
+  env,
+  wsConnectionsTable: storageStack.wsConnectionsTable,
+});
 
 new HermesEmailStack(app, 'HermesEmailStack', {
   env,

--- a/infra/lambda/ws-connect/index.js
+++ b/infra/lambda/ws-connect/index.js
@@ -1,0 +1,4 @@
+// Implementation tracked in issue #19
+exports.handler = async (event) => {
+  return { statusCode: 200 };
+};

--- a/infra/lambda/ws-disconnect/index.js
+++ b/infra/lambda/ws-disconnect/index.js
@@ -1,0 +1,4 @@
+// Implementation tracked in issue #20
+exports.handler = async (event) => {
+  return { statusCode: 200 };
+};

--- a/infra/lib/hermes-websocket-stack.ts
+++ b/infra/lib/hermes-websocket-stack.ts
@@ -1,0 +1,76 @@
+import * as cdk from 'aws-cdk-lib/core';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import { WebSocketLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as path from 'path';
+import { Construct } from 'constructs';
+
+const HERMES_TAG = { key: 'Project', value: 'hermes' };
+
+export interface HermesWebSocketStackProps extends cdk.StackProps {
+  wsConnectionsTable: dynamodb.ITable;
+}
+
+export class HermesWebSocketStack extends cdk.Stack {
+  public readonly webSocketApi: apigatewayv2.WebSocketApi;
+  public readonly webSocketEndpoint: string;
+  public readonly webSocketApiArn: string;
+
+  constructor(scope: Construct, id: string, props: HermesWebSocketStackProps) {
+    super(scope, id, props);
+
+    const connectHandler = new lambda.Function(this, 'WsConnectHandler', {
+      functionName: 'hermes-ws-connect',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/ws-connect')),
+      environment: {
+        WS_CONNECTIONS_TABLE: props.wsConnectionsTable.tableName,
+      },
+    });
+    cdk.Tags.of(connectHandler).add(HERMES_TAG.key, HERMES_TAG.value);
+    props.wsConnectionsTable.grantWriteData(connectHandler);
+
+    const disconnectHandler = new lambda.Function(this, 'WsDisconnectHandler', {
+      functionName: 'hermes-ws-disconnect',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/ws-disconnect')),
+      environment: {
+        WS_CONNECTIONS_TABLE: props.wsConnectionsTable.tableName,
+      },
+    });
+    cdk.Tags.of(disconnectHandler).add(HERMES_TAG.key, HERMES_TAG.value);
+    props.wsConnectionsTable.grantWriteData(disconnectHandler);
+
+    this.webSocketApi = new apigatewayv2.WebSocketApi(this, 'WebSocketApi', {
+      apiName: 'hermes-websocket',
+      connectRouteOptions: {
+        integration: new WebSocketLambdaIntegration('ConnectIntegration', connectHandler),
+      },
+      disconnectRouteOptions: {
+        integration: new WebSocketLambdaIntegration('DisconnectIntegration', disconnectHandler),
+      },
+    });
+    cdk.Tags.of(this.webSocketApi).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    const stage = new apigatewayv2.WebSocketStage(this, 'ProdStage', {
+      webSocketApi: this.webSocketApi,
+      stageName: 'prod',
+      autoDeploy: true,
+    });
+
+    this.webSocketEndpoint = stage.url;
+    this.webSocketApiArn = this.formatArn({
+      service: 'execute-api',
+      resource: this.webSocketApi.apiId,
+    });
+
+    new cdk.CfnOutput(this, 'WebSocketEndpointOutput', {
+      exportName: 'HermesWebSocketEndpoint',
+      value: stage.url,
+      description: 'Hermes WebSocket API endpoint URL',
+    });
+  }
+}

--- a/infra/test/hermes-websocket-stack.test.ts
+++ b/infra/test/hermes-websocket-stack.test.ts
@@ -1,0 +1,111 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
+
+describe('HermesWebSocketStack', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const app = new cdk.App();
+    const helperStack = new cdk.Stack(app, 'HelperStack');
+    const wsTable = dynamodb.Table.fromTableArn(
+      helperStack,
+      'MockWsTable',
+      'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-ws-connections',
+    );
+    const stack = new HermesWebSocketStack(app, 'TestHermesWebSocketStack', {
+      wsConnectionsTable: wsTable,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  describe('WebSocket API', () => {
+    test('creates WebSocket API named hermes-websocket', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+        Name: 'hermes-websocket',
+        ProtocolType: 'WEBSOCKET',
+      });
+    });
+
+    test('creates $connect route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: '$connect',
+      });
+    });
+
+    test('creates $disconnect route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: '$disconnect',
+      });
+    });
+
+    test('creates prod stage with autoDeploy', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Stage', {
+        StageName: 'prod',
+        AutoDeploy: true,
+      });
+    });
+
+    test('outputs WebSocket endpoint URL', () => {
+      template.hasOutput('WebSocketEndpointOutput', {
+        Export: { Name: 'HermesWebSocketEndpoint' },
+      });
+    });
+  });
+
+  describe('WsConnectHandler Lambda', () => {
+    test('creates WsConnectHandler with Node.js 20.x runtime', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-ws-connect',
+        Runtime: 'nodejs20.x',
+        Handler: 'index.handler',
+      });
+    });
+
+    test('WsConnectHandler has WS_CONNECTIONS_TABLE env var', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-ws-connect',
+        Environment: {
+          Variables: Match.objectLike({
+            WS_CONNECTIONS_TABLE: 'hermes-ws-connections',
+          }),
+        },
+      });
+    });
+
+    test('WsConnectHandler has DynamoDB write permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(['dynamodb:PutItem', 'dynamodb:UpdateItem']),
+              Effect: 'Allow',
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('WsDisconnectHandler Lambda', () => {
+    test('creates WsDisconnectHandler with Node.js 20.x runtime', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-ws-disconnect',
+        Runtime: 'nodejs20.x',
+        Handler: 'index.handler',
+      });
+    });
+
+    test('WsDisconnectHandler has WS_CONNECTIONS_TABLE env var', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-ws-disconnect',
+        Environment: {
+          Variables: Match.objectLike({
+            WS_CONNECTIONS_TABLE: 'hermes-ws-connections',
+          }),
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
…dlers (#10)

- New HermesWebSocketStack
- WebSocket API hermes-websocket with $connect and $disconnect routes
- WsConnectHandler Lambda (hermes-ws-connect, Node.js 20.x) - impl tracked in #19
- WsDisconnectHandler Lambda (hermes-ws-disconnect, Node.js 20.x) - impl tracked in #20
- DynamoDB write permissions on hermes-ws-connections for both handlers
- prod stage with autoDeploy enabled
- WebSocket endpoint URL exported as HermesWebSocketEndpoint
- Tagged Project=hermes
- 10 unit tests passing

closes #10