### PR TITLE
[feat]: add CDK Lambda InboundEmailProcessor definition to HermesEmai…

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -20,5 +20,9 @@ const webSocketStack = new HermesWebSocketStack(app, 'HermesWebSocketStack', {
 
 new HermesEmailStack(app, 'HermesEmailStack', {
   env,
-  emailBucketArn: storageStack.emailBucket.bucketArn,
+  emailBucket: storageStack.emailBucket,
+  messagesTable: storageStack.messagesTable,
+  wsConnectionsTable: storageStack.wsConnectionsTable,
+  websocketApiEndpoint: webSocketStack.webSocketEndpoint,
+  websocketApiArn: webSocketStack.webSocketApiArn,
 });

--- a/infra/lambda/inbound-email-processor/index.js
+++ b/infra/lambda/inbound-email-processor/index.js
@@ -1,0 +1,4 @@
+// Implementation tracked in issue #18
+exports.handler = async (event) => {
+  console.log('InboundEmailProcessor triggered', JSON.stringify(event));
+};

--- a/infra/lib/hermes-email-stack.ts
+++ b/infra/lib/hermes-email-stack.ts
@@ -1,17 +1,27 @@
 import * as cdk from 'aws-cdk-lib/core';
 import * as ses from 'aws-cdk-lib/aws-ses';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3n from 'aws-cdk-lib/aws-s3-notifications';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as path from 'path';
 import { Construct } from 'constructs';
 
 const HERMES_TAG = { key: 'Project', value: 'hermes' };
 
 export interface HermesEmailStackProps extends cdk.StackProps {
-  emailBucketArn: string;
+  emailBucket: s3.IBucket;
+  messagesTable: dynamodb.ITable;
+  wsConnectionsTable: dynamodb.ITable;
+  websocketApiEndpoint: string;
+  websocketApiArn: string;
 }
 
 export class HermesEmailStack extends cdk.Stack {
   public readonly receiptRuleSet: ses.CfnReceiptRuleSet;
   public readonly sesS3DeliveryRole: iam.Role;
+  public readonly inboundEmailProcessor: lambda.Function;
 
   constructor(scope: Construct, id: string, props: HermesEmailStackProps) {
     super(scope, id, props);
@@ -38,9 +48,40 @@ export class HermesEmailStack extends cdk.Stack {
     this.sesS3DeliveryRole.addToPolicy(new iam.PolicyStatement({
       sid: 'AllowSesInboundDelivery',
       actions: ['s3:PutObject'],
-      resources: [`${props.emailBucketArn}/inbound/*`],
+      resources: [`${props.emailBucket.bucketArn}/inbound/*`],
     }));
 
     cdk.Tags.of(this.sesS3DeliveryRole).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    this.inboundEmailProcessor = new lambda.Function(this, 'InboundEmailProcessor', {
+      functionName: 'hermes-inbound-email-processor',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/inbound-email-processor')),
+      environment: {
+        MESSAGES_TABLE: props.messagesTable.tableName,
+        WS_CONNECTIONS_TABLE: props.wsConnectionsTable.tableName,
+        S3_BUCKET: props.emailBucket.bucketName,
+        WEBSOCKET_API_ENDPOINT: props.websocketApiEndpoint,
+      },
+    });
+    cdk.Tags.of(this.inboundEmailProcessor).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    props.emailBucket.grantRead(this.inboundEmailProcessor);
+    props.emailBucket.grantPut(this.inboundEmailProcessor);
+    props.messagesTable.grantReadWriteData(this.inboundEmailProcessor);
+    props.wsConnectionsTable.grantReadWriteData(this.inboundEmailProcessor);
+
+    this.inboundEmailProcessor.addToRolePolicy(new iam.PolicyStatement({
+      sid: 'AllowWebSocketManageConnections',
+      actions: ['execute-api:ManageConnections'],
+      resources: [`${props.websocketApiArn}/*`],
+    }));
+
+    props.emailBucket.addEventNotification(
+      s3.EventType.OBJECT_CREATED,
+      new s3n.LambdaDestination(this.inboundEmailProcessor),
+      { prefix: 'inbound/' },
+    );
   }
 }

--- a/infra/test/hermes-email-stack.test.ts
+++ b/infra/test/hermes-email-stack.test.ts
@@ -1,16 +1,31 @@
 import * as cdk from 'aws-cdk-lib/core';
 import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { HermesEmailStack } from '../lib/hermes-email-stack';
 
 const MOCK_BUCKET_ARN = 'arn:aws:s3:::hermes-email-store';
+const MOCK_MESSAGES_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-messages';
+const MOCK_WS_TABLE_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-ws-connections';
+const MOCK_WS_ENDPOINT = 'wss://abc123.execute-api.us-east-1.amazonaws.com/prod';
+const MOCK_WS_API_ARN = 'arn:aws:execute-api:us-east-1:123456789012:abc123';
 
 describe('HermesEmailStack', () => {
   let template: Template;
 
   beforeEach(() => {
     const app = new cdk.App();
+    const helperStack = new cdk.Stack(app, 'HelperStack');
+    const emailBucket = s3.Bucket.fromBucketArn(helperStack, 'MockBucket', MOCK_BUCKET_ARN);
+    const messagesTable = dynamodb.Table.fromTableArn(helperStack, 'MockMessagesTable', MOCK_MESSAGES_TABLE_ARN);
+    const wsTable = dynamodb.Table.fromTableArn(helperStack, 'MockWsTable', MOCK_WS_TABLE_ARN);
+
     const stack = new HermesEmailStack(app, 'TestHermesEmailStack', {
-      emailBucketArn: MOCK_BUCKET_ARN,
+      emailBucket,
+      messagesTable,
+      wsConnectionsTable: wsTable,
+      websocketApiEndpoint: MOCK_WS_ENDPOINT,
+      websocketApiArn: MOCK_WS_API_ARN,
     });
     template = Template.fromStack(stack);
   });
@@ -68,6 +83,58 @@ describe('HermesEmailStack', () => {
       template.hasResourceProperties('AWS::IAM::Role', {
         RoleName: 'hermes-ses-s3-delivery',
         Tags: Match.arrayWith([{ Key: 'Project', Value: 'hermes' }]),
+      });
+    });
+  });
+
+  describe('InboundEmailProcessor Lambda', () => {
+    test('creates InboundEmailProcessor with Node.js 20.x runtime', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-inbound-email-processor',
+        Runtime: 'nodejs20.x',
+        Handler: 'index.handler',
+      });
+    });
+
+    test('InboundEmailProcessor has all required environment variables', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-inbound-email-processor',
+        Environment: {
+          Variables: Match.objectLike({
+            MESSAGES_TABLE: 'hermes-messages',
+            WS_CONNECTIONS_TABLE: 'hermes-ws-connections',
+            S3_BUCKET: 'hermes-email-store',
+            WEBSOCKET_API_ENDPOINT: MOCK_WS_ENDPOINT,
+          }),
+        },
+      });
+    });
+
+    test('InboundEmailProcessor has execute-api:ManageConnections permission', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'AllowWebSocketManageConnections',
+              Action: 'execute-api:ManageConnections',
+              Effect: 'Allow',
+              Resource: `${MOCK_WS_API_ARN}/*`,
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('InboundEmailProcessor has S3 read and write permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: Match.arrayWith(['s3:GetObject*']),
+              Effect: 'Allow',
+            }),
+          ]),
+        },
       });
     });
   });


### PR DESCRIPTION
…lStack (#9)

- Lambda hermes-inbound-email-processor (Node.js 20.x) - impl tracked in #18
- S3 trigger on hermes-email-store with inbound/ prefix filter
- IAM: S3 GetObject/PutObject, DynamoDB read/write on Messages and WsConnections
- IAM: execute-api:ManageConnections on WebSocket API
- Env vars: MESSAGES_TABLE, WS_CONNECTIONS_TABLE, S3_BUCKET, WEBSOCKET_API_ENDPOINT
- Refactored HermesEmailStack props to use IBucket/ITable constructs
- Tagged Project=hermes

closes #9