### PR TITLE
[feat]: add CDK Cognito User Pool, ECR repo, and App Runner service (…

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -3,6 +3,7 @@ import * as cdk from 'aws-cdk-lib/core';
 import { HermesStorageStack } from '../lib/hermes-storage-stack';
 import { HermesEmailStack } from '../lib/hermes-email-stack';
 import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
+import { HermesAppStack } from '../lib/hermes-app-stack';
 
 const app = new cdk.App();
 
@@ -25,4 +26,15 @@ new HermesEmailStack(app, 'HermesEmailStack', {
   wsConnectionsTable: storageStack.wsConnectionsTable,
   websocketApiEndpoint: webSocketStack.webSocketEndpoint,
   websocketApiArn: webSocketStack.webSocketApiArn,
+});
+
+new HermesAppStack(app, 'HermesAppStack', {
+  env,
+  emailBucket: storageStack.emailBucket,
+  addressesTable: storageStack.addressesTable,
+  messagesTable: storageStack.messagesTable,
+  draftsTable: storageStack.draftsTable,
+  wsConnectionsTable: storageStack.wsConnectionsTable,
+  sesRuleSetName: 'hermes-receipt-rules',
+  websocketEndpoint: webSocketStack.webSocketEndpoint,
 });

--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -1,0 +1,200 @@
+import * as cdk from 'aws-cdk-lib/core';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as apprunner from 'aws-cdk-lib/aws-apprunner';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+const HERMES_TAG = { key: 'Project', value: 'hermes' };
+
+export interface HermesAppStackProps extends cdk.StackProps {
+  emailBucket: s3.IBucket;
+  addressesTable: dynamodb.ITable;
+  messagesTable: dynamodb.ITable;
+  draftsTable: dynamodb.ITable;
+  wsConnectionsTable: dynamodb.ITable;
+  sesRuleSetName: string;
+  websocketEndpoint: string;
+}
+
+export class HermesAppStack extends cdk.Stack {
+  public readonly userPool: cognito.CfnUserPool;
+  public readonly userPoolClient: cognito.CfnUserPoolClient;
+  public readonly ecrRepository: ecr.Repository;
+
+  constructor(scope: Construct, id: string, props: HermesAppStackProps) {
+    super(scope, id, props);
+
+    // ── Cognito User Pool (#11) ─────────────────────────────────────────────
+
+    this.userPool = new cognito.CfnUserPool(this, 'UserPool', {
+      userPoolName: 'hermes-user-pool',
+      adminCreateUserConfig: {
+        allowAdminCreateUserOnly: true,
+      },
+      policies: {
+        passwordPolicy: {
+          minimumLength: 12,
+          requireUppercase: true,
+          requireLowercase: true,
+          requireNumbers: true,
+          requireSymbols: true,
+        },
+      },
+      autoVerifiedAttributes: ['email'],
+    });
+    cdk.Tags.of(this.userPool).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    this.userPoolClient = new cognito.CfnUserPoolClient(this, 'UserPoolClient', {
+      clientName: 'hermes-app-client',
+      userPoolId: this.userPool.ref,
+      explicitAuthFlows: ['ALLOW_USER_PASSWORD_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'],
+      generateSecret: false,
+    });
+
+    const adminSecret = new secretsmanager.Secret(this, 'AdminSecret', {
+      secretName: 'hermes-admin-credentials',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ username: 'admin' }),
+        generateStringKey: 'password',
+        excludePunctuation: true,
+        passwordLength: 16,
+      },
+    });
+    cdk.Tags.of(adminSecret).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    // Admin user is created in FORCE_CHANGE_PASSWORD state.
+    // Set the initial password with:
+    //   aws cognito-idp admin-set-user-password \
+    //     --user-pool-id <pool-id> \
+    //     --username admin \
+    //     --password $(aws secretsmanager get-secret-value --secret-id hermes-admin-credentials --query SecretString --output text | jq -r .password) \
+    //     --permanent
+    new cognito.CfnUserPoolUser(this, 'AdminUser', {
+      userPoolId: this.userPool.ref,
+      username: 'admin',
+    });
+
+    new cdk.CfnOutput(this, 'UserPoolIdOutput', {
+      exportName: 'HermesUserPoolId',
+      value: this.userPool.ref,
+      description: 'Hermes Cognito User Pool ID',
+    });
+
+    new cdk.CfnOutput(this, 'UserPoolClientIdOutput', {
+      exportName: 'HermesUserPoolClientId',
+      value: this.userPoolClient.ref,
+      description: 'Hermes Cognito App Client ID',
+    });
+
+    // ── ECR Repository (#12) ────────────────────────────────────────────────
+
+    this.ecrRepository = new ecr.Repository(this, 'AppRepository', {
+      repositoryName: 'hermes-app',
+      imageScanOnPush: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    this.ecrRepository.addLifecycleRule({
+      description: 'Keep last 10 images',
+      maxImageCount: 10,
+    });
+    cdk.Tags.of(this.ecrRepository).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    // ── App Runner (#13) ────────────────────────────────────────────────────
+
+    const accessRole = new iam.Role(this, 'AppRunnerAccessRole', {
+      roleName: 'hermes-app-runner-ecr-access',
+      assumedBy: new iam.ServicePrincipal('build.apprunner.amazonaws.com'),
+    });
+    accessRole.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSAppRunnerServicePolicyForECRAccess'),
+    );
+    cdk.Tags.of(accessRole).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    const instanceRole = new iam.Role(this, 'AppRunnerInstanceRole', {
+      roleName: 'hermes-app-runner-instance',
+      assumedBy: new iam.ServicePrincipal('tasks.apprunner.amazonaws.com'),
+    });
+    cdk.Tags.of(instanceRole).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    // SES permissions
+    instanceRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'SesPermissions',
+      actions: [
+        'ses:SendRawEmail',
+        'ses:ListIdentities',
+        'ses:CreateEmailIdentity',
+        'ses:DeleteEmailIdentity',
+        'ses:CreateReceiptRule',
+        'ses:DeleteReceiptRule',
+        'ses:DescribeReceiptRule',
+      ],
+      resources: ['*'],
+    }));
+
+    // S3 permissions
+    props.emailBucket.grantReadWrite(instanceRole);
+    props.emailBucket.grantDelete(instanceRole);
+
+    // DynamoDB permissions
+    props.addressesTable.grantReadWriteData(instanceRole);
+    props.messagesTable.grantReadWriteData(instanceRole);
+    props.draftsTable.grantReadWriteData(instanceRole);
+    props.wsConnectionsTable.grantReadWriteData(instanceRole);
+
+    // Cognito permissions
+    instanceRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'CognitoPermissions',
+      actions: ['cognito-idp:GetUser'],
+      resources: [this.userPool.attrArn],
+    }));
+
+    const autoScaling = new apprunner.CfnAutoScalingConfiguration(this, 'AutoScaling', {
+      autoScalingConfigurationName: 'hermes-scaling',
+      minSize: 1,
+      maxSize: 3,
+    });
+    cdk.Tags.of(autoScaling).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    const appRunnerService = new apprunner.CfnService(this, 'AppRunnerService', {
+      serviceName: 'hermes-app',
+      sourceConfiguration: {
+        authenticationConfiguration: {
+          accessRoleArn: accessRole.roleArn,
+        },
+        imageRepository: {
+          imageIdentifier: `${this.ecrRepository.repositoryUri}:latest`,
+          imageRepositoryType: 'ECR',
+          imageConfiguration: {
+            port: '3000',
+            runtimeEnvironmentVariables: [
+              { name: 'ADDRESSES_TABLE', value: props.addressesTable.tableName },
+              { name: 'MESSAGES_TABLE', value: props.messagesTable.tableName },
+              { name: 'DRAFTS_TABLE', value: props.draftsTable.tableName },
+              { name: 'WS_CONNECTIONS_TABLE', value: props.wsConnectionsTable.tableName },
+              { name: 'S3_BUCKET', value: props.emailBucket.bucketName },
+              { name: 'SES_RULE_SET_NAME', value: props.sesRuleSetName },
+              { name: 'COGNITO_USER_POOL_ID', value: this.userPool.ref },
+              { name: 'COGNITO_CLIENT_ID', value: this.userPoolClient.ref },
+              { name: 'WEBSOCKET_ENDPOINT', value: props.websocketEndpoint },
+            ],
+          },
+        },
+      },
+      instanceConfiguration: {
+        instanceRoleArn: instanceRole.roleArn,
+      },
+      autoScalingConfigurationArn: autoScaling.attrAutoScalingConfigurationArn,
+    });
+    cdk.Tags.of(appRunnerService).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    new cdk.CfnOutput(this, 'AppRunnerServiceUrlOutput', {
+      exportName: 'HermesAppRunnerServiceUrl',
+      value: appRunnerService.attrServiceUrl,
+      description: 'Hermes App Runner service URL',
+    });
+  }
+}

--- a/infra/test/hermes-app-stack.test.ts
+++ b/infra/test/hermes-app-stack.test.ts
@@ -1,0 +1,194 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { HermesAppStack } from '../lib/hermes-app-stack';
+
+const MOCK_BUCKET_ARN = 'arn:aws:s3:::hermes-email-store';
+const MOCK_ADDRESSES_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-addresses';
+const MOCK_MESSAGES_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-messages';
+const MOCK_DRAFTS_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-drafts';
+const MOCK_WS_ARN = 'arn:aws:dynamodb:us-east-1:123456789012:table/hermes-ws-connections';
+const MOCK_WS_ENDPOINT = 'wss://abc123.execute-api.us-east-1.amazonaws.com/prod';
+
+describe('HermesAppStack', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const app = new cdk.App();
+    const helperStack = new cdk.Stack(app, 'HelperStack');
+    const emailBucket = s3.Bucket.fromBucketArn(helperStack, 'MockBucket', MOCK_BUCKET_ARN);
+    const addressesTable = dynamodb.Table.fromTableArn(helperStack, 'MockAddresses', MOCK_ADDRESSES_ARN);
+    const messagesTable = dynamodb.Table.fromTableArn(helperStack, 'MockMessages', MOCK_MESSAGES_ARN);
+    const draftsTable = dynamodb.Table.fromTableArn(helperStack, 'MockDrafts', MOCK_DRAFTS_ARN);
+    const wsTable = dynamodb.Table.fromTableArn(helperStack, 'MockWs', MOCK_WS_ARN);
+
+    const stack = new HermesAppStack(app, 'TestHermesAppStack', {
+      emailBucket,
+      addressesTable,
+      messagesTable,
+      draftsTable,
+      wsConnectionsTable: wsTable,
+      sesRuleSetName: 'hermes-receipt-rules',
+      websocketEndpoint: MOCK_WS_ENDPOINT,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  describe('Cognito User Pool (#11)', () => {
+    test('creates User Pool named hermes-user-pool', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        UserPoolName: 'hermes-user-pool',
+      });
+    });
+
+    test('self-sign-up is disabled', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        AdminCreateUserConfig: {
+          AllowAdminCreateUserOnly: true,
+        },
+      });
+    });
+
+    test('creates App Client with USER_PASSWORD_AUTH and REFRESH_TOKEN_AUTH', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+        ClientName: 'hermes-app-client',
+        ExplicitAuthFlows: Match.arrayWith([
+          'ALLOW_USER_PASSWORD_AUTH',
+          'ALLOW_REFRESH_TOKEN_AUTH',
+        ]),
+      });
+    });
+
+    test('creates admin user', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPoolUser', {
+        Username: 'admin',
+      });
+    });
+
+    test('creates Secrets Manager secret for admin credentials', () => {
+      template.hasResourceProperties('AWS::SecretsManager::Secret', {
+        Name: 'hermes-admin-credentials',
+      });
+    });
+
+    test('outputs User Pool ID', () => {
+      template.hasOutput('UserPoolIdOutput', {
+        Export: { Name: 'HermesUserPoolId' },
+      });
+    });
+
+    test('outputs App Client ID', () => {
+      template.hasOutput('UserPoolClientIdOutput', {
+        Export: { Name: 'HermesUserPoolClientId' },
+      });
+    });
+  });
+
+  describe('ECR Repository (#12)', () => {
+    test('creates ECR repository named hermes-app', () => {
+      template.hasResourceProperties('AWS::ECR::Repository', {
+        RepositoryName: 'hermes-app',
+      });
+    });
+
+    test('image scan on push is enabled', () => {
+      template.hasResourceProperties('AWS::ECR::Repository', {
+        ImageScanningConfiguration: {
+          ScanOnPush: true,
+        },
+      });
+    });
+
+    test('lifecycle policy keeps last 10 images', () => {
+      template.hasResourceProperties('AWS::ECR::Repository', {
+        LifecyclePolicy: {
+          LifecyclePolicyText: Match.stringLikeRegexp('"countNumber":10'),
+        },
+      });
+    });
+  });
+
+  describe('App Runner Service (#13)', () => {
+    test('creates App Runner service named hermes-app', () => {
+      template.hasResourceProperties('AWS::AppRunner::Service', {
+        ServiceName: 'hermes-app',
+      });
+    });
+
+    test('App Runner service uses ECR image source', () => {
+      template.hasResourceProperties('AWS::AppRunner::Service', {
+        SourceConfiguration: {
+          ImageRepository: {
+            ImageRepositoryType: 'ECR',
+          },
+        },
+      });
+    });
+
+    test('App Runner auto-scaling is min 1 max 3', () => {
+      template.hasResourceProperties('AWS::AppRunner::AutoScalingConfiguration', {
+        AutoScalingConfigurationName: 'hermes-scaling',
+        MinSize: 1,
+        MaxSize: 3,
+      });
+    });
+
+    test('instance role trusted by tasks.apprunner.amazonaws.com', () => {
+      template.hasResourceProperties('AWS::IAM::Role', {
+        RoleName: 'hermes-app-runner-instance',
+        AssumeRolePolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Principal: { Service: 'tasks.apprunner.amazonaws.com' },
+              Action: 'sts:AssumeRole',
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('instance role has SES permissions', () => {
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Sid: 'SesPermissions',
+              Action: Match.arrayWith([
+                'ses:SendRawEmail',
+                'ses:ListIdentities',
+              ]),
+              Effect: 'Allow',
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('App Runner service has all required environment variables', () => {
+      template.hasResourceProperties('AWS::AppRunner::Service', {
+        SourceConfiguration: {
+          ImageRepository: {
+            ImageConfiguration: {
+              RuntimeEnvironmentVariables: Match.arrayWith([
+                Match.objectLike({ Name: 'ADDRESSES_TABLE', Value: 'hermes-addresses' }),
+                Match.objectLike({ Name: 'MESSAGES_TABLE', Value: 'hermes-messages' }),
+                Match.objectLike({ Name: 'DRAFTS_TABLE', Value: 'hermes-drafts' }),
+                Match.objectLike({ Name: 'WS_CONNECTIONS_TABLE', Value: 'hermes-ws-connections' }),
+                Match.objectLike({ Name: 'S3_BUCKET', Value: 'hermes-email-store' }),
+                Match.objectLike({ Name: 'SES_RULE_SET_NAME', Value: 'hermes-receipt-rules' }),
+                Match.objectLike({ Name: 'WEBSOCKET_ENDPOINT', Value: MOCK_WS_ENDPOINT }),
+              ]),
+            },
+          },
+        },
+      });
+    });
+
+    test('outputs App Runner service URL', () => {
+      template.hasOutput('AppRunnerServiceUrlOutput', {
+        Export: { Name: 'HermesAppRunnerServiceUrl' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
…#11 #12 #13)

Cognito (#11):
- User Pool hermes-user-pool with self-sign-up disabled
- App Client hermes-app-client with USER_PASSWORD_AUTH and REFRESH_TOKEN_AUTH
- Admin user created; initial password stored in Secrets Manager hermes-admin-credentials
- Outputs: HermesUserPoolId, HermesUserPoolClientId

ECR (#12):
- Repository hermes-app with image scan on push
- Lifecycle policy retaining last 10 images

App Runner (#13):
- Service hermes-app sourced from ECR hermes-app
- Instance role hermes-app-runner-instance with SES, S3, DynamoDB, Cognito permissions
- Auto-scaling: min 1, max 3
- All env vars wired: table names, bucket, SES rule set, Cognito IDs, WebSocket endpoint
- Output: HermesAppRunnerServiceUrl
- Tagged Project=hermes throughout

closes #11
closes #12
closes #13