### PR TITLE
[feat]: add Cognito authentication, sign-in page, and session middlew…

### DIFF
--- a/app/app/api/auth/signout/route.ts
+++ b/app/app/api/auth/signout/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from '@/lib/auth/cookies';
+
+export async function POST() {
+  const response = NextResponse.redirect(
+    new URL('/login', process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'),
+  );
+
+  const cookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: 0,
+  };
+
+  response.cookies.set(ACCESS_TOKEN_COOKIE, '', cookieOptions);
+  response.cookies.set(REFRESH_TOKEN_COOKIE, '', cookieOptions);
+
+  return response;
+}

--- a/app/app/login/actions.ts
+++ b/app/app/login/actions.ts
@@ -1,0 +1,52 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { signIn, CognitoAuthError } from '@/lib/auth/cognito';
+import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from '@/lib/auth/cookies';
+
+export interface LoginState {
+  error?: string;
+}
+
+export async function loginAction(
+  _prevState: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const username = formData.get('username') as string;
+  const password = formData.get('password') as string;
+
+  if (!username || !password) {
+    return { error: 'Username and password are required.' };
+  }
+
+  try {
+    const tokens = await signIn(username, password);
+    const cookieStore = await cookies();
+
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    cookieStore.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: tokens.expiresIn,
+    });
+
+    cookieStore.set(REFRESH_TOKEN_COOKIE, tokens.refreshToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 30 * 24 * 60 * 60,
+    });
+  } catch (err) {
+    if (err instanceof CognitoAuthError) {
+      return { error: 'Invalid username or password.' };
+    }
+    return { error: 'An unexpected error occurred. Please try again.' };
+  }
+
+  redirect('/');
+}

--- a/app/app/login/login-form.tsx
+++ b/app/app/login/login-form.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useActionState } from 'react';
+import { loginAction, type LoginState } from './actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+const initialState: LoginState = {};
+
+export function LoginForm() {
+  const [state, formAction, isPending] = useActionState(loginAction, initialState);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="username">Username</Label>
+        <Input
+          id="username"
+          name="username"
+          type="text"
+          autoComplete="username"
+          required
+          disabled={isPending}
+          placeholder="admin"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          disabled={isPending}
+        />
+      </div>
+
+      <Button type="submit" className="w-full" disabled={isPending}>
+        {isPending ? 'Signing in...' : 'Sign in'}
+      </Button>
+    </form>
+  );
+}

--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -1,0 +1,24 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { LoginForm } from './login-form';
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Hermes</CardTitle>
+          <CardDescription>Sign in to your account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <LoginForm />
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/lib/auth/cognito.ts
+++ b/app/lib/auth/cognito.ts
@@ -1,0 +1,94 @@
+import {
+  CognitoIdentityProviderClient,
+  InitiateAuthCommand,
+  type InitiateAuthCommandOutput,
+} from '@aws-sdk/client-cognito-identity-provider';
+
+const cognitoClient = new CognitoIdentityProviderClient({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+});
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string;
+  expiresIn: number;
+}
+
+export class CognitoAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CognitoAuthError';
+  }
+}
+
+export async function signIn(username: string, password: string): Promise<AuthTokens> {
+  const clientId = process.env.COGNITO_CLIENT_ID;
+  if (!clientId) {
+    throw new CognitoAuthError('Server misconfiguration: COGNITO_CLIENT_ID not set');
+  }
+
+  let result: InitiateAuthCommandOutput;
+  try {
+    result = await cognitoClient.send(
+      new InitiateAuthCommand({
+        AuthFlow: 'USER_PASSWORD_AUTH',
+        ClientId: clientId,
+        AuthParameters: {
+          USERNAME: username,
+          PASSWORD: password,
+        },
+      }),
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Authentication failed';
+    throw new CognitoAuthError(message);
+  }
+
+  const auth = result.AuthenticationResult;
+  if (!auth?.AccessToken || !auth.RefreshToken || !auth.IdToken) {
+    throw new CognitoAuthError('Incomplete authentication result from Cognito');
+  }
+
+  return {
+    accessToken: auth.AccessToken,
+    refreshToken: auth.RefreshToken,
+    idToken: auth.IdToken,
+    expiresIn: auth.ExpiresIn ?? 3600,
+  };
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<AuthTokens> {
+  const clientId = process.env.COGNITO_CLIENT_ID;
+  if (!clientId) {
+    throw new CognitoAuthError('Server misconfiguration: COGNITO_CLIENT_ID not set');
+  }
+
+  let result: InitiateAuthCommandOutput;
+  try {
+    result = await cognitoClient.send(
+      new InitiateAuthCommand({
+        AuthFlow: 'REFRESH_TOKEN_AUTH',
+        ClientId: clientId,
+        AuthParameters: {
+          REFRESH_TOKEN: refreshToken,
+        },
+      }),
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Token refresh failed';
+    throw new CognitoAuthError(message);
+  }
+
+  const auth = result.AuthenticationResult;
+  if (!auth?.AccessToken || !auth.IdToken) {
+    throw new CognitoAuthError('Incomplete token refresh result from Cognito');
+  }
+
+  return {
+    accessToken: auth.AccessToken,
+    refreshToken,
+    idToken: auth.IdToken,
+    expiresIn: auth.ExpiresIn ?? 3600,
+  };
+}

--- a/app/lib/auth/cookies.ts
+++ b/app/lib/auth/cookies.ts
@@ -1,0 +1,50 @@
+import { type NextResponse, type NextRequest } from 'next/server';
+import { type AuthTokens } from './cognito';
+
+export const ACCESS_TOKEN_COOKIE = 'access_token';
+export const REFRESH_TOKEN_COOKIE = 'refresh_token';
+
+const SECURE = process.env.NODE_ENV === 'production';
+
+export function setAuthCookies(response: NextResponse, tokens: AuthTokens): void {
+  response.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, {
+    httpOnly: true,
+    secure: SECURE,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: tokens.expiresIn,
+  });
+
+  response.cookies.set(REFRESH_TOKEN_COOKIE, tokens.refreshToken, {
+    httpOnly: true,
+    secure: SECURE,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  });
+}
+
+export function clearAuthCookies(response: NextResponse): void {
+  response.cookies.set(ACCESS_TOKEN_COOKIE, '', {
+    httpOnly: true,
+    secure: SECURE,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  response.cookies.set(REFRESH_TOKEN_COOKIE, '', {
+    httpOnly: true,
+    secure: SECURE,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+}
+
+export function getAccessToken(req: NextRequest): string | undefined {
+  return req.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+}
+
+export function getRefreshToken(req: NextRequest): string | undefined {
+  return req.cookies.get(REFRESH_TOKEN_COOKIE)?.value;
+}

--- a/app/lib/auth/jwks-cache.ts
+++ b/app/lib/auth/jwks-cache.ts
@@ -1,0 +1,21 @@
+import { createRemoteJWKSet, type JWTVerifyGetKey } from 'jose';
+
+const JWKS_CACHE: Map<string, { jwks: JWTVerifyGetKey; fetchedAt: number }> = new Map();
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export function getJwks(userPoolId: string, region: string): JWTVerifyGetKey {
+  const jwksUri = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`;
+  const cached = JWKS_CACHE.get(jwksUri);
+
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.jwks;
+  }
+
+  const jwks = createRemoteJWKSet(new URL(jwksUri));
+  JWKS_CACHE.set(jwksUri, { jwks, fetchedAt: Date.now() });
+  return jwks;
+}
+
+export function clearJwksCache(): void {
+  JWKS_CACHE.clear();
+}

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,0 +1,83 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { jwtVerify } from 'jose';
+import { getJwks } from '@/lib/auth/jwks-cache';
+import { refreshAccessToken, CognitoAuthError } from '@/lib/auth/cognito';
+import {
+  ACCESS_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE,
+} from '@/lib/auth/cookies';
+
+const PUBLIC_PATHS = ['/login', '/api/auth/signout'];
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (isPublicPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  const accessToken = req.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = req.cookies.get(REFRESH_TOKEN_COOKIE)?.value;
+
+  if (!accessToken && !refreshToken) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  const userPoolId = process.env.COGNITO_USER_POOL_ID;
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+
+  if (!userPoolId) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  const issuer = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
+
+  if (accessToken) {
+    try {
+      const jwks = getJwks(userPoolId, region);
+      await jwtVerify(accessToken, jwks, { issuer });
+      return NextResponse.next();
+    } catch {
+      // Access token invalid or expired — try refresh below
+    }
+  }
+
+  if (!refreshToken) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  try {
+    const tokens = await refreshAccessToken(refreshToken);
+    const response = NextResponse.next();
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    response.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: tokens.expiresIn,
+    });
+
+    return response;
+  } catch (err) {
+    if (err instanceof CognitoAuthError) {
+      const loginUrl = new URL('/login', req.url);
+      const resp = NextResponse.redirect(loginUrl);
+      resp.cookies.set(ACCESS_TOKEN_COOKIE, '', { maxAge: 0, path: '/' });
+      resp.cookies.set(REFRESH_TOKEN_COOKIE, '', { maxAge: 0, path: '/' });
+      return resp;
+    }
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
…are (#15)

- Sign-in page (/login) using shadcn/ui Card, Input, Button, Label, and Alert components
- Server action calls Cognito USER_PASSWORD_AUTH and stores access and refresh tokens in httpOnly cookies (not accessible via JavaScript)
- Next.js middleware protects all routes and redirects unauthenticated users to /login
- Expired access tokens are refreshed transparently using REFRESH_TOKEN_AUTH
- POST /api/auth/signout clears auth cookies and redirects to /login
- JWKS fetched and cached with 10-minute TTL for middleware JWT verification

closes #15