### PR TITLE
[feat]: add Sprint 1 tests for auth, JWT validation, and CDK stack sy…

### DIFF
--- a/app/__tests__/app/login/login-form.test.tsx
+++ b/app/__tests__/app/login/login-form.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoginForm } from '@/app/login/login-form';
+
+// ── Mock server action ────────────────────────────────────────────────────────
+const mockLoginAction = jest.fn();
+jest.mock('@/app/login/actions', () => ({
+  loginAction: (...args: unknown[]) => mockLoginAction(...args),
+}));
+
+// React's useActionState needs to be shimmed for jsdom
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useActionState: (
+    action: (state: unknown, formData: FormData) => Promise<unknown>,
+    initialState: unknown,
+  ) => {
+    const [state, setState] = jest.requireActual('react').useState(initialState);
+    const dispatch = async (formData: FormData) => {
+      const newState = await action(state, formData);
+      setState(newState);
+    };
+    return [state, dispatch, false];
+  },
+}));
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    mockLoginAction.mockReset();
+  });
+
+  test('renders username and password fields', () => {
+    render(<LoginForm />);
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  });
+
+  test('renders sign in button', () => {
+    render(<LoginForm />);
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  test('shows error alert when action returns an error', async () => {
+    mockLoginAction.mockResolvedValueOnce({ error: 'Invalid username or password.' });
+
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'wrongpass');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Invalid username or password.')).toBeInTheDocument();
+    });
+  });
+
+  test('does not show error alert on initial render', () => {
+    render(<LoginForm />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/app/__tests__/lib/auth/jwks-cache.test.ts
+++ b/app/__tests__/lib/auth/jwks-cache.test.ts
@@ -1,0 +1,66 @@
+import { getJwks, clearJwksCache } from '@/lib/auth/jwks-cache';
+
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn((url: URL) => ({ _url: url.toString() })),
+}));
+
+import { createRemoteJWKSet } from 'jose';
+const mockCreate = createRemoteJWKSet as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearJwksCache();
+});
+
+describe('getJwks', () => {
+  test('creates a new JWKS for a given user pool', () => {
+    getJwks('us-east-1_TestPool', 'us-east-1');
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith(
+      new URL('https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool/.well-known/jwks.json'),
+    );
+  });
+
+  test('returns cached JWKS on second call without fetching again', () => {
+    const first = getJwks('us-east-1_TestPool', 'us-east-1');
+    const second = getJwks('us-east-1_TestPool', 'us-east-1');
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  test('creates separate JWKS for different user pools', () => {
+    getJwks('us-east-1_Pool1', 'us-east-1');
+    getJwks('us-east-1_Pool2', 'us-east-1');
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  test('re-fetches after cache TTL expires', () => {
+    jest.useFakeTimers();
+
+    getJwks('us-east-1_TestPool', 'us-east-1');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    // Advance past the 10-minute TTL
+    jest.advanceTimersByTime(11 * 60 * 1000);
+
+    getJwks('us-east-1_TestPool', 'us-east-1');
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  test('does NOT re-fetch before TTL expires', () => {
+    jest.useFakeTimers();
+
+    getJwks('us-east-1_TestPool', 'us-east-1');
+    jest.advanceTimersByTime(9 * 60 * 1000);
+    getJwks('us-east-1_TestPool', 'us-east-1');
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+});

--- a/app/__tests__/lib/auth/require-auth.test.ts
+++ b/app/__tests__/lib/auth/require-auth.test.ts
@@ -1,0 +1,169 @@
+import { type NextRequest } from 'next/server';
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+import { clearJwksCache } from '@/lib/auth/jwks-cache';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(overrides: {
+  authHeader?: string;
+  accessTokenCookie?: string;
+} = {}): NextRequest {
+  const url = 'http://localhost:3000/api/test';
+  const headers = new Headers();
+
+  if (overrides.authHeader !== undefined) {
+    headers.set('authorization', overrides.authHeader);
+  }
+
+  const req = {
+    headers,
+    cookies: {
+      get: (name: string) => {
+        if (name === 'access_token' && overrides.accessTokenCookie !== undefined) {
+          return { value: overrides.accessTokenCookie };
+        }
+        return undefined;
+      },
+    },
+    url,
+  } as unknown as NextRequest;
+
+  return req;
+}
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/auth/jwks-cache', () => ({
+  getJwks: jest.fn(),
+  clearJwksCache: jest.fn(),
+}));
+
+jest.mock('jose', () => ({
+  jwtVerify: jest.fn(),
+}));
+
+import { getJwks } from '@/lib/auth/jwks-cache';
+import { jwtVerify } from 'jose';
+
+const mockGetJwks = getJwks as jest.Mock;
+const mockJwtVerify = jwtVerify as jest.Mock;
+const FAKE_JWKS = Symbol('fakeJwks');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.COGNITO_USER_POOL_ID = 'us-east-1_TestPool';
+  process.env.AWS_REGION = 'us-east-1';
+  mockGetJwks.mockReturnValue(FAKE_JWKS);
+});
+
+afterEach(() => {
+  clearJwksCache();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('requireAuth', () => {
+  describe('valid token', () => {
+    test('returns decoded claims from Bearer header', async () => {
+      const claims = { sub: 'user-123', 'cognito:username': 'admin', token_use: 'access' };
+      mockJwtVerify.mockResolvedValueOnce({ payload: claims });
+
+      const req = makeRequest({ authHeader: 'Bearer valid.jwt.token' });
+      const result = await requireAuth(req);
+
+      expect(result).toEqual(claims);
+    });
+
+    test('returns decoded claims from access_token cookie', async () => {
+      const claims = { sub: 'user-456', email: 'admin@example.com' };
+      mockJwtVerify.mockResolvedValueOnce({ payload: claims });
+
+      const req = makeRequest({ accessTokenCookie: 'cookie.jwt.token' });
+      const result = await requireAuth(req);
+
+      expect(result).toEqual(claims);
+    });
+
+    test('prefers Authorization header over cookie', async () => {
+      const claims = { sub: 'from-header' };
+      mockJwtVerify.mockResolvedValueOnce({ payload: claims });
+
+      const req = makeRequest({
+        authHeader: 'Bearer header.jwt.token',
+        accessTokenCookie: 'cookie.jwt.token',
+      });
+      const result = await requireAuth(req);
+
+      expect(mockJwtVerify).toHaveBeenCalledWith(
+        'header.jwt.token',
+        FAKE_JWKS,
+        expect.any(Object),
+      );
+      expect(result).toEqual(claims);
+    });
+  });
+
+  describe('missing token', () => {
+    test('throws AuthError 401 when no header and no cookie', async () => {
+      const req = makeRequest();
+
+      await expect(requireAuth(req)).rejects.toThrow(AuthError);
+      await expect(requireAuth(req)).rejects.toMatchObject({ status: 401 });
+    });
+
+    test('throws AuthError with descriptive message', async () => {
+      const req = makeRequest();
+      await expect(requireAuth(req)).rejects.toThrow('Missing authentication token');
+    });
+  });
+
+  describe('invalid or expired token', () => {
+    test('throws AuthError 401 when jwtVerify rejects', async () => {
+      mockJwtVerify.mockRejectedValueOnce(new Error('JWTExpired'));
+
+      const req = makeRequest({ authHeader: 'Bearer expired.token' });
+      await expect(requireAuth(req)).rejects.toMatchObject({
+        status: 401,
+        message: 'Invalid or expired token',
+      });
+    });
+
+    test('throws AuthError on tampered signature', async () => {
+      mockJwtVerify.mockRejectedValueOnce(new Error('JWSSignatureVerificationFailed'));
+
+      const req = makeRequest({ authHeader: 'Bearer tampered.token' });
+      await expect(requireAuth(req)).rejects.toMatchObject({ status: 401 });
+    });
+  });
+
+  describe('JWKS caching', () => {
+    test('getJwks is called with correct userPoolId and region', async () => {
+      mockJwtVerify.mockResolvedValueOnce({ payload: { sub: 'u1' } });
+
+      const req = makeRequest({ authHeader: 'Bearer some.token' });
+      await requireAuth(req);
+
+      expect(mockGetJwks).toHaveBeenCalledWith('us-east-1_TestPool', 'us-east-1');
+    });
+
+    test('getJwks is called on every requireAuth call (caching is inside getJwks)', async () => {
+      mockJwtVerify.mockResolvedValue({ payload: { sub: 'u1' } });
+
+      const req1 = makeRequest({ authHeader: 'Bearer token1' });
+      const req2 = makeRequest({ authHeader: 'Bearer token2' });
+      await requireAuth(req1);
+      await requireAuth(req2);
+
+      expect(mockGetJwks).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('server misconfiguration', () => {
+    test('throws AuthError 500 when COGNITO_USER_POOL_ID is missing', async () => {
+      delete process.env.COGNITO_USER_POOL_ID;
+
+      const req = makeRequest({ authHeader: 'Bearer some.token' });
+      await expect(requireAuth(req)).rejects.toMatchObject({ status: 500 });
+    });
+  });
+});

--- a/app/__tests__/middleware/middleware.test.ts
+++ b/app/__tests__/middleware/middleware.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { middleware } from '@/middleware';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('jose', () => ({
+  jwtVerify: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/jwks-cache', () => ({
+  getJwks: jest.fn().mockReturnValue(Symbol('jwks')),
+}));
+
+jest.mock('@/lib/auth/cognito', () => ({
+  refreshAccessToken: jest.fn(),
+  CognitoAuthError: class CognitoAuthError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'CognitoAuthError';
+    }
+  },
+}));
+
+import { jwtVerify } from 'jose';
+import { refreshAccessToken, CognitoAuthError } from '@/lib/auth/cognito';
+
+const mockJwtVerify = jwtVerify as jest.Mock;
+const mockRefresh = refreshAccessToken as jest.Mock;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(pathname: string, cookies: Record<string, string> = {}): NextRequest {
+  const url = `http://localhost:3000${pathname}`;
+  const req = new NextRequest(url);
+
+  for (const [name, value] of Object.entries(cookies)) {
+    req.cookies.set(name, value);
+  }
+
+  return req;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.COGNITO_USER_POOL_ID = 'us-east-1_TestPool';
+  process.env.AWS_REGION = 'us-east-1';
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('middleware', () => {
+  describe('public paths', () => {
+    test('/login is accessible without authentication', async () => {
+      const req = makeReq('/login');
+      const res = await middleware(req);
+      expect(res.status).not.toBe(302);
+    });
+
+    test('/api/auth/signout is accessible without authentication', async () => {
+      const req = makeReq('/api/auth/signout');
+      const res = await middleware(req);
+      expect(res.status).not.toBe(302);
+    });
+  });
+
+  describe('unauthenticated requests to protected routes', () => {
+    test('redirects to /login when no cookies present', async () => {
+      const req = makeReq('/');
+      const res = await middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+
+    test('redirects to /login for any protected route', async () => {
+      const req = makeReq('/inbox');
+      const res = await middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+  });
+
+  describe('valid access token', () => {
+    test('allows the request to proceed', async () => {
+      mockJwtVerify.mockResolvedValueOnce({ payload: { sub: 'user-1' } });
+
+      const req = makeReq('/', { access_token: 'valid.jwt.token' });
+      const res = await middleware(req);
+
+      expect(res.status).not.toBe(307);
+    });
+  });
+
+  describe('expired access token with valid refresh token', () => {
+    test('refreshes the access token and allows the request', async () => {
+      mockJwtVerify.mockRejectedValueOnce(new Error('JWTExpired'));
+      mockRefresh.mockResolvedValueOnce({
+        accessToken: 'new.access.token',
+        refreshToken: 'existing.refresh.token',
+        idToken: 'new.id.token',
+        expiresIn: 3600,
+      });
+
+      const req = makeReq('/', {
+        access_token: 'expired.token',
+        refresh_token: 'valid.refresh.token',
+      });
+      const res = await middleware(req);
+
+      expect(res.status).not.toBe(307);
+      const setCookie = res.headers.get('set-cookie');
+      expect(setCookie).toContain('access_token=new.access.token');
+    });
+  });
+
+  describe('expired access token with invalid refresh token', () => {
+    test('redirects to /login and clears cookies', async () => {
+      mockJwtVerify.mockRejectedValueOnce(new Error('JWTExpired'));
+      mockRefresh.mockRejectedValueOnce(new CognitoAuthError('Refresh token expired'));
+
+      const req = makeReq('/', {
+        access_token: 'expired.token',
+        refresh_token: 'expired.refresh',
+      });
+      const res = await middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+  });
+
+  describe('sign-out', () => {
+    test('POST /api/auth/signout is accessible (public path)', async () => {
+      const req = makeReq('/api/auth/signout');
+      const res = await middleware(req);
+      expect(res.status).not.toBe(307);
+    });
+  });
+});

--- a/infra/test/full-app-synthesis.test.ts
+++ b/infra/test/full-app-synthesis.test.ts
@@ -1,0 +1,51 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { HermesStorageStack } from '../lib/hermes-storage-stack';
+import { HermesEmailStack } from '../lib/hermes-email-stack';
+import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
+import { HermesAppStack } from '../lib/hermes-app-stack';
+
+/**
+ * Full app synthesis integration test.
+ *
+ * Instantiates all four stacks together the same way bin/infra.ts does.
+ * This catches cross-stack circular dependencies that per-stack unit tests
+ * cannot detect, because those tests mock the cross-stack resource handles.
+ */
+describe('Full CDK app synthesis (integration)', () => {
+  test('all stacks synthesise together without errors', () => {
+    expect(() => {
+      const app = new cdk.App();
+
+      const env = { account: '123456789012', region: 'us-east-1' };
+
+      const storageStack = new HermesStorageStack(app, 'HermesStorageStack', { env });
+
+      const webSocketStack = new HermesWebSocketStack(app, 'HermesWebSocketStack', {
+        env,
+        wsConnectionsTable: storageStack.wsConnectionsTable,
+      });
+
+      new HermesEmailStack(app, 'HermesEmailStack', {
+        env,
+        emailBucket: storageStack.emailBucket,
+        messagesTable: storageStack.messagesTable,
+        wsConnectionsTable: storageStack.wsConnectionsTable,
+        websocketApiEndpoint: webSocketStack.webSocketEndpoint,
+        websocketApiArn: webSocketStack.webSocketApiArn,
+      });
+
+      new HermesAppStack(app, 'HermesAppStack', {
+        env,
+        emailBucket: storageStack.emailBucket,
+        addressesTable: storageStack.addressesTable,
+        messagesTable: storageStack.messagesTable,
+        draftsTable: storageStack.draftsTable,
+        wsConnectionsTable: storageStack.wsConnectionsTable,
+        sesRuleSetName: 'hermes-receipt-rules',
+        websocketEndpoint: webSocketStack.webSocketEndpoint,
+      });
+
+      app.synth();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
…nthesis (#17)

- Unit tests for JWKS cache: TTL expiry, per-pool isolation, cache hit/miss
- Unit tests for requireAuth: valid token, missing token, expired token, tampered signature, JWKS delegation, and server misconfiguration (401/500)
- Integration tests for Next.js middleware: public paths, unauthenticated redirect, valid token passthrough, transparent token refresh, and sign-out
- Component tests for LoginForm: field rendering, sign-in button, error alert display
- CDK full-app synthesis integration test: all four stacks wired together via app.synth() to catch cross-stack circular dependencies

closes #17