### PR TITLE
[fix]: configure App Runner health check to use /login (#62)

### DIFF
--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -183,6 +183,14 @@ export class HermesAppStack extends cdk.Stack {
       instanceConfiguration: {
         instanceRoleArn: instanceRole.roleArn,
       },
+      healthCheckConfiguration: {
+        protocol: 'HTTP',
+        path: '/login',
+        interval: 10,
+        timeout: 5,
+        healthyThreshold: 1,
+        unhealthyThreshold: 5,
+      },
       autoScalingConfigurationArn: autoScaling.attrAutoScalingConfigurationArn,
     });
     cdk.Tags.of(appRunnerService).add(HERMES_TAG.key, HERMES_TAG.value);

--- a/infra/test/hermes-app-stack.test.ts
+++ b/infra/test/hermes-app-stack.test.ts
@@ -186,6 +186,15 @@ describe('HermesAppStack', () => {
       });
     });
 
+    test('health check uses /login path so middleware redirect does not fail the check (#62)', () => {
+      template.hasResourceProperties('AWS::AppRunner::Service', {
+        HealthCheckConfiguration: {
+          Protocol: 'HTTP',
+          Path: '/login',
+        },
+      });
+    });
+
     test('outputs App Runner service URL', () => {
       template.hasOutput('AppRunnerServiceUrlOutput', {
         Export: { Name: 'HermesAppRunnerServiceUrl' },


### PR DESCRIPTION
App Runner probes GET / after startup; the Next.js middleware redirects unauthenticated requests to /login (HTTP 302), which App Runner treats as unhealthy — causing the service to never stabilise (CREATE_FAILED).

Set healthCheckConfiguration.path to /login, which always returns 200 for unauthenticated visitors.

closes #62