### PR TITLE
[fix]: build Docker image for linux/amd64 to run on App Runner (#64)

### DIFF
--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -6,7 +6,7 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as apprunner from 'aws-cdk-lib/aws-apprunner';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
+import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 
 const HERMES_TAG = { key: 'Project', value: 'hermes' };
@@ -96,6 +96,7 @@ export class HermesAppStack extends cdk.Stack {
 
     const appImage = new DockerImageAsset(this, 'AppImage', {
       directory: path.join(__dirname, '../../app'),
+      platform: Platform.LINUX_AMD64,
     });
 
     // ── App Runner (#13) ────────────────────────────────────────────────────


### PR DESCRIPTION
The image was built on Apple Silicon (arm64) and App Runner runs on x86_64 hosts — an arm64 image cannot execute, causing NotStabilized.

Pass Platform.LINUX_AMD64 to DockerImageAsset so CDK always cross-builds an amd64 image regardless of the local machine architecture.

closes #64