### PR TITLE
[feat]: migrate from App Runner to Lambda Web Adapter + CloudFront (#70)

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -29,6 +29,8 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 /lambda-adapter /opt/extensions/lambda-adapter
+
 COPY --from=builder /app/public ./public
 
 RUN mkdir .next && chown nextjs:nodejs .next
@@ -41,6 +43,6 @@ USER nextjs
 EXPOSE 3000
 
 ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV READINESS_CHECK_PATH "/login"
 
 CMD ["node", "server.js"]

--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -3,10 +3,13 @@ import * as cdk from 'aws-cdk-lib/core';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as apprunner from 'aws-cdk-lib/aws-apprunner';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Construct } from 'constructs';
 
 const HERMES_TAG = { key: 'Project', value: 'hermes' };
@@ -28,7 +31,7 @@ export class HermesAppStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: HermesAppStackProps) {
     super(scope, id, props);
 
-    // ── Cognito User Pool (#11) ─────────────────────────────────────────────
+    // ── Cognito User Pool ───────────────────────────────────────────────────
 
     this.userPool = new cognito.CfnUserPool(this, 'UserPool', {
       userPoolName: 'hermes-user-pool',
@@ -91,35 +94,18 @@ export class HermesAppStack extends cdk.Stack {
       description: 'Hermes Cognito App Client ID',
     });
 
-    // ── Docker image asset (#12) ────────────────────────────────────────────
-    // CDK builds the Next.js image and pushes it to the bootstrap ECR repo on
-    // every `cdk deploy`. App Runner is updated to the new image URI automatically.
+    // ── Lambda execution role ───────────────────────────────────────────────
 
-    const appImage = new DockerImageAsset(this, 'AppImage', {
-      directory: path.join(__dirname, '../../app'),
-      platform: Platform.LINUX_AMD64,
+    const executionRole = new iam.Role(this, 'AppFunctionRole', {
+      roleName: 'hermes-app-function',
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
+      ],
     });
+    cdk.Tags.of(executionRole).add(HERMES_TAG.key, HERMES_TAG.value);
 
-    // ── App Runner (#13) ────────────────────────────────────────────────────
-
-    const accessRole = new iam.Role(this, 'AppRunnerAccessRole', {
-      roleName: 'hermes-app-runner-ecr-access',
-      assumedBy: new iam.ServicePrincipal('build.apprunner.amazonaws.com'),
-    });
-    accessRole.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSAppRunnerServicePolicyForECRAccess'),
-    );
-    appImage.repository.grantPull(accessRole);
-    cdk.Tags.of(accessRole).add(HERMES_TAG.key, HERMES_TAG.value);
-
-    const instanceRole = new iam.Role(this, 'AppRunnerInstanceRole', {
-      roleName: 'hermes-app-runner-instance',
-      assumedBy: new iam.ServicePrincipal('tasks.apprunner.amazonaws.com'),
-    });
-    cdk.Tags.of(instanceRole).add(HERMES_TAG.key, HERMES_TAG.value);
-
-    // SES permissions
-    instanceRole.addToPolicy(new iam.PolicyStatement({
+    executionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SesPermissions',
       actions: [
         'ses:SendRawEmail',
@@ -133,75 +119,73 @@ export class HermesAppStack extends cdk.Stack {
       resources: ['*'],
     }));
 
-    // S3 permissions
-    props.emailBucket.grantReadWrite(instanceRole);
-    props.emailBucket.grantDelete(instanceRole);
+    props.emailBucket.grantReadWrite(executionRole);
+    props.emailBucket.grantDelete(executionRole);
+    props.addressesTable.grantReadWriteData(executionRole);
+    props.messagesTable.grantReadWriteData(executionRole);
+    props.draftsTable.grantReadWriteData(executionRole);
+    props.wsConnectionsTable.grantReadWriteData(executionRole);
 
-    // DynamoDB permissions
-    props.addressesTable.grantReadWriteData(instanceRole);
-    props.messagesTable.grantReadWriteData(instanceRole);
-    props.draftsTable.grantReadWriteData(instanceRole);
-    props.wsConnectionsTable.grantReadWriteData(instanceRole);
-
-    // Cognito permissions
-    instanceRole.addToPolicy(new iam.PolicyStatement({
+    executionRole.addToPolicy(new iam.PolicyStatement({
       sid: 'CognitoPermissions',
       actions: ['cognito-idp:GetUser'],
       resources: [this.userPool.attrArn],
     }));
 
-    const autoScaling = new apprunner.CfnAutoScalingConfiguration(this, 'AutoScaling', {
-      autoScalingConfigurationName: 'hermes-scaling',
-      minSize: 1,
-      maxSize: 3,
-    });
-    cdk.Tags.of(autoScaling).add(HERMES_TAG.key, HERMES_TAG.value);
+    // ── Lambda function (Next.js container + Lambda Web Adapter) ───────────
 
-    const appRunnerService = new apprunner.CfnService(this, 'AppRunnerService', {
-      serviceName: 'hermes-app',
-      sourceConfiguration: {
-        authenticationConfiguration: {
-          accessRoleArn: accessRole.roleArn,
-        },
-        imageRepository: {
-          imageIdentifier: appImage.imageUri,
-          imageRepositoryType: 'ECR',
-          imageConfiguration: {
-            port: '3000',
-            runtimeEnvironmentVariables: [
-              { name: 'HOSTNAME', value: '0.0.0.0' },
-              { name: 'ADDRESSES_TABLE', value: props.addressesTable.tableName },
-              { name: 'MESSAGES_TABLE', value: props.messagesTable.tableName },
-              { name: 'DRAFTS_TABLE', value: props.draftsTable.tableName },
-              { name: 'WS_CONNECTIONS_TABLE', value: props.wsConnectionsTable.tableName },
-              { name: 'S3_BUCKET', value: props.emailBucket.bucketName },
-              { name: 'SES_RULE_SET_NAME', value: props.sesRuleSetName },
-              { name: 'COGNITO_USER_POOL_ID', value: this.userPool.ref },
-              { name: 'COGNITO_CLIENT_ID', value: this.userPoolClient.ref },
-              { name: 'WEBSOCKET_ENDPOINT', value: props.websocketEndpoint },
-            ],
-          },
-        },
-      },
-      instanceConfiguration: {
-        instanceRoleArn: instanceRole.roleArn,
-      },
-      healthCheckConfiguration: {
-        protocol: 'HTTP',
-        path: '/login',
-        interval: 10,
-        timeout: 5,
-        healthyThreshold: 1,
-        unhealthyThreshold: 5,
-      },
-      autoScalingConfigurationArn: autoScaling.attrAutoScalingConfigurationArn,
+    const appLogGroup = new logs.LogGroup(this, 'AppFunctionLogGroup', {
+      logGroupName: '/aws/lambda/hermes-app',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
-    cdk.Tags.of(appRunnerService).add(HERMES_TAG.key, HERMES_TAG.value);
 
-    new cdk.CfnOutput(this, 'AppRunnerServiceUrlOutput', {
-      exportName: 'HermesAppRunnerServiceUrl',
-      value: appRunnerService.attrServiceUrl,
-      description: 'Hermes App Runner service URL',
+    const appFunction = new lambda.DockerImageFunction(this, 'AppFunction', {
+      functionName: 'hermes-app',
+      code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../../app'), {
+        platform: Platform.LINUX_AMD64,
+      }),
+      memorySize: 512,
+      timeout: cdk.Duration.seconds(30),
+      architecture: lambda.Architecture.X86_64,
+      role: executionRole,
+      logGroup: appLogGroup,
+      environment: {
+        PORT: '3000',
+        ADDRESSES_TABLE: props.addressesTable.tableName,
+        MESSAGES_TABLE: props.messagesTable.tableName,
+        DRAFTS_TABLE: props.draftsTable.tableName,
+        WS_CONNECTIONS_TABLE: props.wsConnectionsTable.tableName,
+        S3_BUCKET: props.emailBucket.bucketName,
+        SES_RULE_SET_NAME: props.sesRuleSetName,
+        COGNITO_USER_POOL_ID: this.userPool.ref,
+        COGNITO_CLIENT_ID: this.userPoolClient.ref,
+        WEBSOCKET_ENDPOINT: props.websocketEndpoint,
+      },
+    });
+    cdk.Tags.of(appFunction).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    // ── Function URL + CloudFront ───────────────────────────────────────────
+
+    const functionUrl = appFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+    });
+
+    const distribution = new cloudfront.Distribution(this, 'AppDistribution', {
+      defaultBehavior: {
+        origin: new origins.FunctionUrlOrigin(functionUrl),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+      },
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+    });
+    cdk.Tags.of(distribution).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    new cdk.CfnOutput(this, 'AppUrlOutput', {
+      exportName: 'HermesAppUrl',
+      value: `https://${distribution.distributionDomainName}`,
+      description: 'Hermes app URL (CloudFront)',
     });
   }
 }

--- a/infra/test/hermes-app-stack.test.ts
+++ b/infra/test/hermes-app-stack.test.ts
@@ -35,7 +35,7 @@ describe('HermesAppStack', () => {
     template = Template.fromStack(stack);
   });
 
-  describe('Cognito User Pool (#11)', () => {
+  describe('Cognito User Pool', () => {
     test('creates User Pool named hermes-user-pool', () => {
       template.hasResourceProperties('AWS::Cognito::UserPool', {
         UserPoolName: 'hermes-user-pool',
@@ -44,9 +44,7 @@ describe('HermesAppStack', () => {
 
     test('self-sign-up is disabled', () => {
       template.hasResourceProperties('AWS::Cognito::UserPool', {
-        AdminCreateUserConfig: {
-          AllowAdminCreateUserOnly: true,
-        },
+        AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
       });
     });
 
@@ -73,75 +71,50 @@ describe('HermesAppStack', () => {
     });
 
     test('outputs User Pool ID', () => {
-      template.hasOutput('UserPoolIdOutput', {
-        Export: { Name: 'HermesUserPoolId' },
-      });
+      template.hasOutput('UserPoolIdOutput', { Export: { Name: 'HermesUserPoolId' } });
     });
 
     test('outputs App Client ID', () => {
-      template.hasOutput('UserPoolClientIdOutput', {
-        Export: { Name: 'HermesUserPoolClientId' },
-      });
+      template.hasOutput('UserPoolClientIdOutput', { Export: { Name: 'HermesUserPoolClientId' } });
     });
   });
 
-  describe('Docker image asset (#12)', () => {
-    test('DockerImageAsset does not create a named ECR repository in the stack', () => {
-      // The image is pushed to the CDK bootstrap ECR repo, which lives outside
-      // this stack — no AWS::ECR::Repository resource should appear here.
-      template.resourceCountIs('AWS::ECR::Repository', 0);
-    });
-
-    test('App Runner access role has ECR pull permissions granted by the image asset', () => {
-      template.hasResourceProperties('AWS::IAM::Policy', {
-        PolicyDocument: {
-          Statement: Match.arrayWith([
-            Match.objectLike({
-              Action: Match.arrayWith([
-                'ecr:BatchCheckLayerAvailability',
-                'ecr:GetDownloadUrlForLayer',
-                'ecr:BatchGetImage',
-              ]),
-              Effect: 'Allow',
-            }),
-          ]),
-        },
-      });
-    });
-  });
-
-  describe('App Runner Service (#13)', () => {
-    test('creates App Runner service named hermes-app', () => {
-      template.hasResourceProperties('AWS::AppRunner::Service', {
-        ServiceName: 'hermes-app',
+  describe('Lambda function (Next.js + Lambda Web Adapter)', () => {
+    test('creates Lambda function named hermes-app', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-app',
+        PackageType: 'Image',
+        MemorySize: 512,
+        Timeout: 30,
+        Architectures: ['x86_64'],
       });
     });
 
-    test('App Runner service uses ECR image source', () => {
-      template.hasResourceProperties('AWS::AppRunner::Service', {
-        SourceConfiguration: {
-          ImageRepository: {
-            ImageRepositoryType: 'ECR',
-          },
+    test('Lambda function has all required environment variables', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-app',
+        Environment: {
+          Variables: Match.objectLike({
+            PORT: '3000',
+            ADDRESSES_TABLE: 'hermes-addresses',
+            MESSAGES_TABLE: 'hermes-messages',
+            DRAFTS_TABLE: 'hermes-drafts',
+            WS_CONNECTIONS_TABLE: 'hermes-ws-connections',
+            S3_BUCKET: 'hermes-email-store',
+            SES_RULE_SET_NAME: 'hermes-receipt-rules',
+            WEBSOCKET_ENDPOINT: MOCK_WS_ENDPOINT,
+          }),
         },
       });
     });
 
-    test('App Runner auto-scaling is min 1 max 3', () => {
-      template.hasResourceProperties('AWS::AppRunner::AutoScalingConfiguration', {
-        AutoScalingConfigurationName: 'hermes-scaling',
-        MinSize: 1,
-        MaxSize: 3,
-      });
-    });
-
-    test('instance role trusted by tasks.apprunner.amazonaws.com', () => {
+    test('execution role is trusted by lambda.amazonaws.com', () => {
       template.hasResourceProperties('AWS::IAM::Role', {
-        RoleName: 'hermes-app-runner-instance',
+        RoleName: 'hermes-app-function',
         AssumeRolePolicyDocument: {
           Statement: Match.arrayWith([
             Match.objectLike({
-              Principal: { Service: 'tasks.apprunner.amazonaws.com' },
+              Principal: { Service: 'lambda.amazonaws.com' },
               Action: 'sts:AssumeRole',
             }),
           ]),
@@ -149,16 +122,13 @@ describe('HermesAppStack', () => {
       });
     });
 
-    test('instance role has SES permissions', () => {
+    test('execution role has SES permissions', () => {
       template.hasResourceProperties('AWS::IAM::Policy', {
         PolicyDocument: {
           Statement: Match.arrayWith([
             Match.objectLike({
               Sid: 'SesPermissions',
-              Action: Match.arrayWith([
-                'ses:SendRawEmail',
-                'ses:ListIdentities',
-              ]),
+              Action: Match.arrayWith(['ses:SendRawEmail', 'ses:ListIdentities']),
               Effect: 'Allow',
             }),
           ]),
@@ -166,39 +136,55 @@ describe('HermesAppStack', () => {
       });
     });
 
-    test('App Runner service has all required environment variables', () => {
-      template.hasResourceProperties('AWS::AppRunner::Service', {
-        SourceConfiguration: {
-          ImageRepository: {
-            ImageConfiguration: {
-              RuntimeEnvironmentVariables: Match.arrayWith([
-                Match.objectLike({ Name: 'ADDRESSES_TABLE', Value: 'hermes-addresses' }),
-                Match.objectLike({ Name: 'MESSAGES_TABLE', Value: 'hermes-messages' }),
-                Match.objectLike({ Name: 'DRAFTS_TABLE', Value: 'hermes-drafts' }),
-                Match.objectLike({ Name: 'WS_CONNECTIONS_TABLE', Value: 'hermes-ws-connections' }),
-                Match.objectLike({ Name: 'S3_BUCKET', Value: 'hermes-email-store' }),
-                Match.objectLike({ Name: 'SES_RULE_SET_NAME', Value: 'hermes-receipt-rules' }),
-                Match.objectLike({ Name: 'WEBSOCKET_ENDPOINT', Value: MOCK_WS_ENDPOINT }),
-              ]),
-            },
-          },
-        },
+    test('Lambda log group has DeletionPolicy Delete', () => {
+      const resources = template.toJSON().Resources;
+      const logGroups = Object.values(resources).filter(
+        (r: any) => r.Type === 'AWS::Logs::LogGroup' &&
+          r.Properties?.LogGroupName === '/aws/lambda/hermes-app',
+      );
+      expect(logGroups.length).toBe(1);
+      expect((logGroups[0] as any).DeletionPolicy).toBe('Delete');
+    });
+
+    test('no App Runner resources in stack', () => {
+      template.resourceCountIs('AWS::AppRunner::Service', 0);
+      template.resourceCountIs('AWS::AppRunner::AutoScalingConfiguration', 0);
+    });
+  });
+
+  describe('Function URL + CloudFront', () => {
+    test('creates Lambda Function URL with auth type NONE', () => {
+      template.hasResourceProperties('AWS::Lambda::Url', {
+        AuthType: 'NONE',
       });
     });
 
-    test('health check uses /login path so middleware redirect does not fail the check (#62)', () => {
-      template.hasResourceProperties('AWS::AppRunner::Service', {
-        HealthCheckConfiguration: {
-          Protocol: 'HTTP',
-          Path: '/login',
-        },
+    test('creates CloudFront distribution', () => {
+      template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+    });
+
+    test('CloudFront distribution has caching disabled', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          DefaultCacheBehavior: Match.objectLike({
+            ViewerProtocolPolicy: 'redirect-to-https',
+          }),
+        }),
       });
     });
 
-    test('outputs App Runner service URL', () => {
-      template.hasOutput('AppRunnerServiceUrlOutput', {
-        Export: { Name: 'HermesAppRunnerServiceUrl' },
-      });
+    test('outputs CloudFront app URL', () => {
+      template.hasOutput('AppUrlOutput', { Export: { Name: 'HermesAppUrl' } });
+    });
+  });
+
+  describe('Removal policies', () => {
+    test('admin secret has DeletionPolicy Delete', () => {
+      const resources = template.toJSON().Resources;
+      const secrets = Object.values(resources).filter(
+        (r: any) => r.Type === 'AWS::SecretsManager::Secret',
+      );
+      secrets.forEach((s: any) => expect(s.DeletionPolicy).toBe('Delete'));
     });
   });
 });


### PR DESCRIPTION
- Replace App Runner service and scaling config with DockerImageFunction
- Add Lambda Web Adapter binary to Dockerfile runner stage
- Add CloudFront distribution with FunctionUrlOrigin (caching disabled)
- Replace HOSTNAME env var with READINESS_CHECK_PATH for Lambda adapter
- Update test suite: remove App Runner assertions, add Lambda/CF assertions

closes #70