### PR TITLE
[feat]: serve app from hermes.rpillai.dev custom domain (#69)

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -4,6 +4,7 @@ import { HermesStorageStack } from '../lib/hermes-storage-stack';
 import { HermesEmailStack } from '../lib/hermes-email-stack';
 import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
 import { HermesAppStack } from '../lib/hermes-app-stack';
+import { HermesCertStack } from '../lib/hermes-cert-stack';
 
 const app = new cdk.App();
 
@@ -11,6 +12,9 @@ const env = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
   region: process.env.CDK_DEFAULT_REGION,
 };
+
+const DOMAIN_NAME = 'hermes.rpillai.dev';
+const HOSTED_ZONE_DOMAIN = 'rpillai.dev';
 
 const storageStack = new HermesStorageStack(app, 'HermesStorageStack', { env });
 
@@ -28,8 +32,17 @@ new HermesEmailStack(app, 'HermesEmailStack', {
   websocketApiArn: webSocketStack.webSocketApiArn,
 });
 
+// ACM certificate must be in us-east-1 for CloudFront.
+const certStack = new HermesCertStack(app, 'HermesCertStack', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: 'us-east-1' },
+  domainName: DOMAIN_NAME,
+  hostedZoneDomainName: HOSTED_ZONE_DOMAIN,
+  crossRegionReferences: true,
+});
+
 new HermesAppStack(app, 'HermesAppStack', {
   env,
+  crossRegionReferences: true,
   emailBucket: storageStack.emailBucket,
   addressesTable: storageStack.addressesTable,
   messagesTable: storageStack.messagesTable,
@@ -37,4 +50,7 @@ new HermesAppStack(app, 'HermesAppStack', {
   wsConnectionsTable: storageStack.wsConnectionsTable,
   sesRuleSetName: 'hermes-receipt-rules',
   websocketEndpoint: webSocketStack.webSocketEndpoint,
+  domainName: DOMAIN_NAME,
+  certificate: certStack.certificate,
+  hostedZoneDomainName: HOSTED_ZONE_DOMAIN,
 });

--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib/core';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
@@ -9,6 +10,8 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventTargets from 'aws-cdk-lib/aws-events-targets';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as route53Targets from 'aws-cdk-lib/aws-route53-targets';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
@@ -24,6 +27,12 @@ export interface HermesAppStackProps extends cdk.StackProps {
   wsConnectionsTable: dynamodb.ITable;
   sesRuleSetName: string;
   websocketEndpoint: string;
+  /** Custom domain to serve the app from (e.g. hermes.rpillai.dev). Requires certificate + hostedZoneDomainName. */
+  domainName?: string;
+  /** ACM certificate for domainName — must be in us-east-1. */
+  certificate?: acm.ICertificate;
+  /** Route 53 hosted zone domain (e.g. rpillai.dev) for creating the A record alias. */
+  hostedZoneDomainName?: string;
 }
 
 export class HermesAppStack extends cdk.Stack {
@@ -181,13 +190,33 @@ export class HermesAppStack extends cdk.Stack {
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
       },
       priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      ...(props.domainName && props.certificate ? {
+        domainNames: [props.domainName],
+        certificate: props.certificate,
+      } : {}),
     });
     cdk.Tags.of(distribution).add(HERMES_TAG.key, HERMES_TAG.value);
 
+    // ── Route 53 alias record ───────────────────────────────────────────────
+    if (props.domainName && props.hostedZoneDomainName) {
+      const hostedZone = route53.HostedZone.fromLookup(this, 'HostedZone', {
+        domainName: props.hostedZoneDomainName,
+      });
+      new route53.ARecord(this, 'AppARecord', {
+        zone: hostedZone,
+        recordName: props.domainName,
+        target: route53.RecordTarget.fromAlias(
+          new route53Targets.CloudFrontTarget(distribution),
+        ),
+      });
+    }
+
     new cdk.CfnOutput(this, 'AppUrlOutput', {
       exportName: 'HermesAppUrl',
-      value: `https://${distribution.distributionDomainName}`,
-      description: 'Hermes app URL (CloudFront)',
+      value: props.domainName
+        ? `https://${props.domainName}`
+        : `https://${distribution.distributionDomainName}`,
+      description: 'Hermes app URL',
     });
 
     // ── EventBridge warmer ─────────────────────────────────────────────────

--- a/infra/lib/hermes-cert-stack.ts
+++ b/infra/lib/hermes-cert-stack.ts
@@ -1,0 +1,29 @@
+import * as cdk from 'aws-cdk-lib/core';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import { Construct } from 'constructs';
+
+const HERMES_TAG = { key: 'Project', value: 'hermes' };
+
+export interface HermesCertStackProps extends cdk.StackProps {
+  domainName: string;
+  hostedZoneDomainName: string;
+}
+
+export class HermesCertStack extends cdk.Stack {
+  public readonly certificate: acm.ICertificate;
+
+  constructor(scope: Construct, id: string, props: HermesCertStackProps) {
+    super(scope, id, props);
+
+    const hostedZone = route53.HostedZone.fromLookup(this, 'HostedZone', {
+      domainName: props.hostedZoneDomainName,
+    });
+
+    this.certificate = new acm.Certificate(this, 'Certificate', {
+      domainName: props.domainName,
+      validation: acm.CertificateValidation.fromDns(hostedZone),
+    });
+    cdk.Tags.of(this.certificate).add(HERMES_TAG.key, HERMES_TAG.value);
+  }
+}

--- a/infra/test/hermes-app-stack.test.ts
+++ b/infra/test/hermes-app-stack.test.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib/core';
 import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { HermesAppStack } from '../lib/hermes-app-stack';
@@ -212,6 +213,71 @@ describe('HermesAppStack', () => {
         (r: any) => r.Type === 'AWS::SecretsManager::Secret',
       );
       secrets.forEach((s: any) => expect(s.DeletionPolicy).toBe('Delete'));
+    });
+  });
+
+  describe('Custom domain', () => {
+    const MOCK_HOSTED_ZONE_CONTEXT = {
+      'hosted-zone:account=123456789012:domainName=rpillai.dev:region=us-east-1': {
+        Id: '/hostedzone/Z123456789TEST',
+        Name: 'rpillai.dev.',
+      },
+    };
+
+    let domainTemplate: Template;
+
+    beforeEach(() => {
+      const app = new cdk.App({ context: MOCK_HOSTED_ZONE_CONTEXT });
+      const helperStack = new cdk.Stack(app, 'HelperStack', {
+        env: { account: '123456789012', region: 'us-east-1' },
+      });
+      const emailBucket = s3.Bucket.fromBucketArn(helperStack, 'MockBucket', MOCK_BUCKET_ARN);
+      const addressesTable = dynamodb.Table.fromTableArn(helperStack, 'MockAddresses', MOCK_ADDRESSES_ARN);
+      const messagesTable = dynamodb.Table.fromTableArn(helperStack, 'MockMessages', MOCK_MESSAGES_ARN);
+      const draftsTable = dynamodb.Table.fromTableArn(helperStack, 'MockDrafts', MOCK_DRAFTS_ARN);
+      const wsTable = dynamodb.Table.fromTableArn(helperStack, 'MockWs', MOCK_WS_ARN);
+      const mockCert = acm.Certificate.fromCertificateArn(
+        helperStack,
+        'MockCert',
+        'arn:aws:acm:us-east-1:123456789012:certificate/mock-cert-id',
+      );
+
+      const stack = new HermesAppStack(app, 'TestHermesAppStackDomain', {
+        env: { account: '123456789012', region: 'us-east-1' },
+        emailBucket,
+        addressesTable,
+        messagesTable,
+        draftsTable,
+        wsConnectionsTable: wsTable,
+        sesRuleSetName: 'hermes-receipt-rules',
+        websocketEndpoint: MOCK_WS_ENDPOINT,
+        domainName: 'hermes.rpillai.dev',
+        certificate: mockCert,
+        hostedZoneDomainName: 'rpillai.dev',
+      });
+      domainTemplate = Template.fromStack(stack);
+    });
+
+    test('CloudFront distribution has hermes.rpillai.dev as alias', () => {
+      domainTemplate.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: Match.objectLike({
+          Aliases: ['hermes.rpillai.dev'],
+        }),
+      });
+    });
+
+    test('Route 53 A record targets CloudFront distribution', () => {
+      domainTemplate.resourceCountIs('AWS::Route53::RecordSet', 1);
+      domainTemplate.hasResourceProperties('AWS::Route53::RecordSet', {
+        Name: 'hermes.rpillai.dev.',
+        Type: 'A',
+      });
+    });
+
+    test('AppUrlOutput exports custom domain URL', () => {
+      domainTemplate.hasOutput('AppUrlOutput', {
+        Value: 'https://hermes.rpillai.dev',
+      });
     });
   });
 });

--- a/infra/test/hermes-cert-stack.test.ts
+++ b/infra/test/hermes-cert-stack.test.ts
@@ -1,0 +1,42 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { HermesCertStack } from '../lib/hermes-cert-stack';
+
+const MOCK_HOSTED_ZONE_CONTEXT = {
+  'hosted-zone:account=123456789012:domainName=rpillai.dev:region=us-east-1': {
+    Id: '/hostedzone/Z123456789TEST',
+    Name: 'rpillai.dev.',
+  },
+};
+
+describe('HermesCertStack', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const app = new cdk.App({ context: MOCK_HOSTED_ZONE_CONTEXT });
+    const stack = new HermesCertStack(app, 'TestHermesCertStack', {
+      env: { account: '123456789012', region: 'us-east-1' },
+      domainName: 'hermes.rpillai.dev',
+      hostedZoneDomainName: 'rpillai.dev',
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test('creates ACM certificate for hermes.rpillai.dev', () => {
+    template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+      DomainName: 'hermes.rpillai.dev',
+    });
+  });
+
+  test('certificate uses DNS validation', () => {
+    template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+      ValidationMethod: 'DNS',
+    });
+  });
+
+  test('certificate is tagged with Project=hermes', () => {
+    template.hasResourceProperties('AWS::CertificateManager::Certificate', {
+      Tags: Match.arrayWith([{ Key: 'Project', Value: 'hermes' }]),
+    });
+  });
+});


### PR DESCRIPTION
- Add HermesCertStack (us-east-1) to provision ACM cert with DNS validation
- Add optional domain/certificate/hostedZone props to HermesAppStack
- Wire CloudFront alias + Route 53 A record when domain props provided
- Update AppUrlOutput to export custom domain URL when configured
- Add HermesCertStack tests and custom domain describe block in app stack tests
- Enable crossRegionReferences on cert and app stacks in bin/infra.ts

closes #69