### PR TITLE
[feat]: implement WsDisconnectHandler Lambda with unit tests (#20)

### DIFF
--- a/infra/lambda/ws-disconnect/index.js
+++ b/infra/lambda/ws-disconnect/index.js
@@ -1,4 +1,18 @@
-// Implementation tracked in issue #20
+'use strict';
+
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, DeleteCommand } = require('@aws-sdk/lib-dynamodb');
+
+const WS_CONNECTIONS_TABLE = process.env.WS_CONNECTIONS_TABLE;
+
 exports.handler = async (event) => {
+  const connectionId = event.requestContext.connectionId;
+  const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+  await dynamo.send(new DeleteCommand({
+    TableName: WS_CONNECTIONS_TABLE,
+    Key: { connectionId },
+  }));
+
   return { statusCode: 200 };
 };

--- a/infra/lambda/ws-disconnect/package.json
+++ b/infra/lambda/ws-disconnect/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ws-disconnect",
+  "version": "1.0.0",
+  "description": "Hermes WebSocket $disconnect handler Lambda",
+  "main": "index.js",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0"
+  }
+}

--- a/infra/test/lambda/ws-disconnect.test.ts
+++ b/infra/test/lambda/ws-disconnect.test.ts
@@ -1,0 +1,52 @@
+const mockDynamo = { send: jest.fn() };
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn() },
+  DeleteCommand: jest.fn((p: unknown) => p),
+}));
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+process.env.WS_CONNECTIONS_TABLE = 'hermes-ws-connections';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handler } = require('../../lambda/ws-disconnect/index');
+
+function makeEvent(connectionId = 'conn-abc') {
+  return { requestContext: { connectionId } };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (DynamoDBClient as jest.Mock).mockReturnValue({});
+  (DynamoDBDocumentClient.from as unknown as jest.Mock).mockReturnValue(mockDynamo);
+  mockDynamo.send.mockResolvedValue({});
+});
+
+describe('WsDisconnectHandler', () => {
+  test('returns 200', async () => {
+    const result = await handler(makeEvent());
+    expect(result.statusCode).toBe(200);
+  });
+
+  test('deletes the connection record by connectionId', async () => {
+    await handler(makeEvent('conn-xyz'));
+
+    expect(mockDynamo.send).toHaveBeenCalledTimes(1);
+    const deleteArg = (mockDynamo.send.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(deleteArg).toMatchObject({
+      TableName: 'hermes-ws-connections',
+      Key: { connectionId: 'conn-xyz' },
+    });
+  });
+
+  test('does not error if the record no longer exists (DynamoDB DeleteItem is idempotent)', async () => {
+    mockDynamo.send.mockResolvedValue({});
+    await expect(handler(makeEvent('gone-conn'))).resolves.toMatchObject({ statusCode: 200 });
+  });
+});


### PR DESCRIPTION
- Delete connection record from WsConnections table by connectionId
- DynamoDB DeleteItem is idempotent so missing records are handled gracefully
- 3 unit tests covering happy path, correct key, and missing-record no-error

closes #20