### PR TITLE
[fix]: redirect to /addresses after login instead of / (#96)

### DIFF
--- a/app/app/login/login-form.tsx
+++ b/app/app/login/login-form.tsx
@@ -16,7 +16,7 @@ export function LoginForm() {
 
   useEffect(() => {
     if (state.success) {
-      router.push('/');
+      router.push('/addresses');
     }
   }, [state.success, router]);
 


### PR DESCRIPTION
/ is outside the (app) route group and shows a blank placeholder. /addresses is the authenticated entry point inside the app shell.

closes #96