### PR TITLE
[fix]: remove CreateEmailIdentityCommand — not in @aws-sdk/client-ses…

### DIFF
--- a/app/app/api/addresses/route.ts
+++ b/app/app/api/addresses/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { SESClient, ListIdentitiesCommand, CreateEmailIdentityCommand, CreateReceiptRuleCommand } from '@aws-sdk/client-ses';
+import { SESClient, ListIdentitiesCommand, CreateReceiptRuleCommand } from '@aws-sdk/client-ses';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, ScanCommand, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { requireAuth, AuthError } from '@/lib/auth/require-auth';
@@ -70,9 +70,6 @@ export async function POST(req: NextRequest) {
   if (existing.Item && existing.Item.status !== 'deleted') {
     return NextResponse.json({ error: 'Address already exists' }, { status: 409 });
   }
-
-  // Create SES email identity
-  await ses.send(new CreateEmailIdentityCommand({ EmailIdentity: email }));
 
   // Create SES receipt rule
   const ruleName = `hermes-recv-${email.replace('@', '-at-').replace(/\./g, '-')}`;


### PR DESCRIPTION
… (#95)

CreateEmailIdentityCommand is a SES v2 API and does not exist in @aws-sdk/client-ses (v1), causing a build failure. Domain verification plus a receipt rule is sufficient for inbound email routing.

closes #95