### PR TITLE
[test]: Sprint 3 tests for all frontend core pages (#34)

### DIFF
--- a/app/__tests__/app/login/login-form.test.tsx
+++ b/app/__tests__/app/login/login-form.test.tsx
@@ -8,6 +8,12 @@ jest.mock('@/app/login/actions', () => ({
   loginAction: (...args: unknown[]) => mockLoginAction(...args),
 }));
 
+// ── Mock next/navigation ──────────────────────────────────────────────────────
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 // React's useActionState needs to be shimmed for jsdom
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -27,6 +33,7 @@ jest.mock('react', () => ({
 describe('LoginForm', () => {
   beforeEach(() => {
     mockLoginAction.mockReset();
+    mockPush.mockReset();
   });
 
   test('renders username and password fields', () => {
@@ -59,5 +66,20 @@ describe('LoginForm', () => {
   test('does not show error alert on initial render', () => {
     render(<LoginForm />);
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('redirects to / on successful login', async () => {
+    mockLoginAction.mockResolvedValueOnce({ success: true });
+
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/app/__tests__/components/addresses/delete-address-dialog.test.tsx
+++ b/app/__tests__/components/addresses/delete-address-dialog.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DeleteAddressDialog } from '@/components/addresses/delete-address-dialog';
+
+jest.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTrigger: ({
+    children,
+  }: {
+    children: React.ReactNode;
+    asChild?: boolean;
+  }) => <div data-testid="alert-trigger">{children}</div>,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="alert-content">{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DeleteAddressDialog', () => {
+  test('renders Delete trigger button', () => {
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={jest.fn()} />);
+    const trigger = screen.getByTestId('alert-trigger');
+    expect(within(trigger).getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+  });
+
+  test('shows confirmation dialog with email and warning text', () => {
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={jest.fn()} />);
+    expect(screen.getByText('Delete address')).toBeInTheDocument();
+    expect(screen.getByText(/hello@example.com/)).toBeInTheDocument();
+    expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument();
+  });
+
+  test('shows Cancel and Delete actions in dialog content', () => {
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={jest.fn()} />);
+    const content = screen.getByTestId('alert-content');
+    expect(within(content).getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(within(content).getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+  });
+
+  test('calls DELETE /api/addresses/:email on confirm', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const onSuccess = jest.fn();
+    const user = userEvent.setup();
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={onSuccess} />);
+
+    const content = screen.getByTestId('alert-content');
+    await user.click(within(content).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/addresses/hello%40example.com',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+  });
+
+  test('calls onSuccess after successful delete', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const onSuccess = jest.fn();
+    const user = userEvent.setup();
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={onSuccess} />);
+
+    const content = screen.getByTestId('alert-content');
+    await user.click(within(content).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
+  test('shows alert on API failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Address not found' }),
+    });
+    const user = userEvent.setup();
+    render(<DeleteAddressDialog email="hello@example.com" onSuccess={jest.fn()} />);
+
+    const content = screen.getByTestId('alert-content');
+    await user.click(within(content).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith('Address not found');
+    });
+  });
+});

--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -37,6 +37,24 @@ describe('MessageDetail', () => {
     expect(screen.getByText(/no message body/i)).toBeInTheDocument();
   });
 
+  test('renders sandboxed iframe when bodyHtmlUrl is provided', async () => {
+    (global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url === 'https://s3.example.com/html') {
+        return Promise.resolve({ ok: true, text: async () => '<p>HTML body</p>' });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<MessageDetail message={{ ...BASE_MSG, bodyHtmlUrl: 'https://s3.example.com/html' }} />);
+
+    await waitFor(() => {
+      const iframe = screen.getByTestId('html-body-frame');
+      expect(iframe).toBeInTheDocument();
+      expect(iframe).toHaveAttribute('sandbox', 'allow-same-origin');
+    });
+    expect(global.fetch).toHaveBeenCalledWith('https://s3.example.com/html');
+  });
+
   test('renders plain text body when bodyTextUrl is provided', async () => {
     (global.fetch as jest.Mock).mockImplementation((url: string) => {
       if (url === 'https://s3.example.com/text') {


### PR DESCRIPTION
- Fix login-form.test.tsx: add next/navigation mock so useRouter works in jsdom
- Add test: LoginForm redirects to / on successful login
- Add delete-address-dialog.test.tsx: confirmation dialog, DELETE call, onSuccess, error alert
- Add message-detail.test.tsx: sandboxed iframe rendered when bodyHtmlUrl provided

closes #34