### PR TITLE
[feat]: Draft CRUD endpoints — GET, POST, PUT, DELETE /api/drafts (#37)

### DIFF
--- a/app/__tests__/app/api/drafts/[id]/route.test.ts
+++ b/app/__tests__/app/api/drafts/[id]/route.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: jest.fn(),
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(msg: string, status = 401) { super(msg); this.status = status; }
+  },
+}));
+
+const mockDynamoSend = jest.fn();
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn().mockImplementation(() => ({ send: mockDynamoSend })) },
+  GetCommand: jest.fn((p: unknown) => p),
+  UpdateCommand: jest.fn((p: unknown) => p),
+  DeleteCommand: jest.fn((p: unknown) => p),
+}));
+
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+
+process.env.DRAFTS_TABLE = 'hermes-drafts';
+
+import { PUT, DELETE } from '@/app/api/drafts/[id]/route';
+
+const mockRequireAuth = requireAuth as jest.Mock;
+
+function makeParams(id = 'draft-1') {
+  return Promise.resolve({ id });
+}
+
+function makePutReq(body: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/drafts/draft-1', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDeleteReq() {
+  return new NextRequest('http://localhost/api/drafts/draft-1', { method: 'DELETE' });
+}
+
+const DRAFT_ITEM = {
+  draftId: 'draft-1',
+  userId: 'user-1',
+  subject: 'Original subject',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── PUT /api/drafts/:id ──────────────────────────────────────────────────────
+
+describe('PUT /api/drafts/:id', () => {
+  test('updates draft and returns 200 with draftId', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    const res = await PUT(makePutReq({ subject: 'Updated subject', body: 'New content' }), { params: makeParams() });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.draftId).toBe('draft-1');
+  });
+
+  test('sends UpdateCommand to the correct table', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    await PUT(makePutReq({ subject: 'Hello' }), { params: makeParams() });
+
+    const updateArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect((updateArg as Record<string, unknown>).TableName).toBe('hermes-drafts');
+    expect(((updateArg as Record<string, unknown>).Key as Record<string, unknown>).draftId).toBe('draft-1');
+  });
+
+  test('includes all allowed fields in the update expression', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    const fields = {
+      from: 'me@hermes.com',
+      to: 'them@example.com',
+      cc: 'cc@example.com',
+      bcc: 'bcc@example.com',
+      subject: 'Hello',
+      body: 'Body text',
+      attachmentKeys: ['uploads/key.pdf'],
+      inReplyToMessageId: 'msg-1',
+    };
+
+    await PUT(makePutReq(fields), { params: makeParams() });
+
+    const updateArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0] as Record<string, unknown>;
+    const values = updateArg.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[':from']).toBe('me@hermes.com');
+    expect(values[':to']).toBe('them@example.com');
+    expect(values[':subject']).toBe('Hello');
+    expect(values[':body']).toBe('Body text');
+    expect(values[':inReplyToMessageId']).toBe('msg-1');
+  });
+
+  test('uses condition to prevent unauthorized updates', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    await PUT(makePutReq({ subject: 'Hello' }), { params: makeParams() });
+
+    const updateArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0] as Record<string, unknown>;
+    expect(updateArg.ConditionExpression).toContain('userId = :userId');
+  });
+
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await PUT(makePutReq(), { params: makeParams() });
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toBe('Missing authentication token');
+  });
+});
+
+// ── DELETE /api/drafts/:id ───────────────────────────────────────────────────
+
+describe('DELETE /api/drafts/:id', () => {
+  test('deletes draft and returns 204', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValueOnce({ Item: DRAFT_ITEM }).mockResolvedValueOnce({});
+
+    const res = await DELETE(makeDeleteReq(), { params: makeParams() });
+
+    expect(res.status).toBe(204);
+  });
+
+  test('sends DeleteCommand with correct key', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValueOnce({ Item: DRAFT_ITEM }).mockResolvedValueOnce({});
+
+    await DELETE(makeDeleteReq(), { params: makeParams() });
+
+    const deleteArg = (mockDynamoSend.mock.calls[1] as [Record<string, unknown>])[0] as Record<string, unknown>;
+    expect(deleteArg.TableName).toBe('hermes-drafts');
+    expect((deleteArg.Key as Record<string, unknown>).draftId).toBe('draft-1');
+  });
+
+  test('returns 404 when draft does not exist', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Item: undefined });
+
+    const res = await DELETE(makeDeleteReq(), { params: makeParams() });
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toContain('not found');
+  });
+
+  test('returns 403 when draft belongs to another user', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'different-user' });
+    mockDynamoSend.mockResolvedValue({ Item: DRAFT_ITEM });
+
+    const res = await DELETE(makeDeleteReq(), { params: makeParams() });
+    const json = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(json.error).toBe('Forbidden');
+  });
+
+  test('does not call DeleteCommand when draft does not exist', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Item: undefined });
+
+    await DELETE(makeDeleteReq(), { params: makeParams() });
+
+    expect(mockDynamoSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await DELETE(makeDeleteReq(), { params: makeParams() });
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toBe('Missing authentication token');
+  });
+});

--- a/app/__tests__/app/api/drafts/route.test.ts
+++ b/app/__tests__/app/api/drafts/route.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: jest.fn(),
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(msg: string, status = 401) { super(msg); this.status = status; }
+  },
+}));
+
+const mockDynamoSend = jest.fn();
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn().mockImplementation(() => ({ send: mockDynamoSend })) },
+  ScanCommand: jest.fn((p: unknown) => p),
+  PutCommand: jest.fn((p: unknown) => p),
+}));
+
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+
+process.env.DRAFTS_TABLE = 'hermes-drafts';
+
+import { GET, POST } from '@/app/api/drafts/route';
+
+const mockRequireAuth = requireAuth as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function makeGetReq() {
+  return new NextRequest('http://localhost/api/drafts');
+}
+
+function makePostReq(body: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/drafts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET /api/drafts ─────────────────────────────────────────────────────────
+
+describe('GET /api/drafts', () => {
+  test('returns only drafts belonging to the authenticated user', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({
+      Items: [
+        { draftId: 'draft-1', userId: 'user-1', subject: 'Hello', updatedAt: '2024-01-02T00:00:00Z' },
+        { draftId: 'draft-2', userId: 'user-1', subject: 'World', updatedAt: '2024-01-01T00:00:00Z' },
+      ],
+    });
+
+    const res = await GET(makeGetReq());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.drafts).toHaveLength(2);
+    expect(json.drafts[0].draftId).toBe('draft-1');
+  });
+
+  test('filters by userId in the scan', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-42' });
+    mockDynamoSend.mockResolvedValue({ Items: [] });
+
+    await GET(makeGetReq());
+
+    const scanArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(scanArg).toMatchObject({
+      TableName: 'hermes-drafts',
+      FilterExpression: 'userId = :userId',
+      ExpressionAttributeValues: { ':userId': 'user-42' },
+    });
+  });
+
+  test('returns drafts sorted newest-first by updatedAt', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({
+      Items: [
+        { draftId: 'draft-old', userId: 'user-1', updatedAt: '2024-01-01T00:00:00Z' },
+        { draftId: 'draft-new', userId: 'user-1', updatedAt: '2024-01-03T00:00:00Z' },
+        { draftId: 'draft-mid', userId: 'user-1', updatedAt: '2024-01-02T00:00:00Z' },
+      ],
+    });
+
+    const res = await GET(makeGetReq());
+    const json = await res.json();
+
+    expect(json.drafts[0].draftId).toBe('draft-new');
+    expect(json.drafts[1].draftId).toBe('draft-mid');
+    expect(json.drafts[2].draftId).toBe('draft-old');
+  });
+
+  test('returns empty array when user has no drafts', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Items: [] });
+
+    const res = await GET(makeGetReq());
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.drafts).toEqual([]);
+  });
+
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await GET(makeGetReq());
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toBe('Missing authentication token');
+  });
+
+  test('does not call DynamoDB when auth fails', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    await GET(makeGetReq());
+
+    expect(mockDynamoSend).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /api/drafts ─────────────────────────────────────────────────────────
+
+describe('POST /api/drafts', () => {
+  test('creates draft and returns 201 with draftId', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    const res = await POST(makePostReq({ from: 'me@hermes.com', subject: 'Draft subject' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.draftId).toBeDefined();
+  });
+
+  test('stores userId from JWT claims in the draft', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-99' });
+    mockDynamoSend.mockResolvedValue({});
+
+    await POST(makePostReq({ subject: 'Test' }));
+
+    const putArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    const item = (putArg as Record<string, unknown>).Item as Record<string, unknown>;
+    expect(item.userId).toBe('user-99');
+  });
+
+  test('stores all provided draft fields', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    const draft = {
+      from: 'me@hermes.com',
+      to: 'them@example.com',
+      cc: 'cc@example.com',
+      bcc: 'bcc@example.com',
+      subject: 'Hello',
+      body: 'Draft body',
+      attachmentKeys: ['uploads/uuid/file.pdf'],
+      inReplyToMessageId: 'msg-original',
+    };
+
+    await POST(makePostReq(draft));
+
+    const putArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    const item = (putArg as Record<string, unknown>).Item as Record<string, unknown>;
+    expect(item.from).toBe('me@hermes.com');
+    expect(item.to).toBe('them@example.com');
+    expect(item.cc).toBe('cc@example.com');
+    expect(item.bcc).toBe('bcc@example.com');
+    expect(item.subject).toBe('Hello');
+    expect(item.body).toBe('Draft body');
+    expect(item.attachmentKeys).toEqual(['uploads/uuid/file.pdf']);
+    expect(item.inReplyToMessageId).toBe('msg-original');
+  });
+
+  test('stores createdAt and updatedAt timestamps', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({});
+
+    await POST(makePostReq());
+
+    const putArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    const item = (putArg as Record<string, unknown>).Item as Record<string, unknown>;
+    expect(item.createdAt).toBeDefined();
+    expect(item.updatedAt).toBeDefined();
+  });
+
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await POST(makePostReq());
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toBe('Missing authentication token');
+  });
+});

--- a/app/app/api/drafts/[id]/route.ts
+++ b/app/app/api/drafts/[id]/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+
+function getDynamo() {
+  return DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION ?? 'us-east-1' }));
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  let claims;
+  try {
+    claims = await requireAuth(req);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+
+  const { id: draftId } = await params;
+
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = await req.json();
+  } catch {
+    // empty body results in only updatedAt being set
+  }
+
+  const allowed = ['from', 'to', 'cc', 'bcc', 'subject', 'body', 'attachmentKeys', 'inReplyToMessageId'];
+  const updateParts: string[] = [];
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {
+    ':userId': claims.sub,
+    ':now': new Date().toISOString(),
+  };
+
+  for (const field of allowed) {
+    if (Object.prototype.hasOwnProperty.call(payload, field)) {
+      updateParts.push(`#${field} = :${field}`);
+      names[`#${field}`] = field;
+      values[`:${field}`] = payload[field];
+    }
+  }
+
+  updateParts.push('updatedAt = :now');
+  updateParts.push('userId = :userId');
+
+  const dynamo = getDynamo();
+  await dynamo.send(new UpdateCommand({
+    TableName: process.env.DRAFTS_TABLE!,
+    Key: { draftId },
+    UpdateExpression: `SET ${updateParts.join(', ')}`,
+    ConditionExpression: 'attribute_not_exists(draftId) OR userId = :userId',
+    ExpressionAttributeNames: { ...names },
+    ExpressionAttributeValues: values,
+  }));
+
+  return NextResponse.json({ draftId });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  let claims;
+  try {
+    claims = await requireAuth(req);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+
+  const { id: draftId } = await params;
+  const dynamo = getDynamo();
+
+  const existing = await dynamo.send(new GetCommand({
+    TableName: process.env.DRAFTS_TABLE!,
+    Key: { draftId },
+  }));
+
+  if (!existing.Item) {
+    return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  if (existing.Item.userId !== claims.sub) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await dynamo.send(new DeleteCommand({
+    TableName: process.env.DRAFTS_TABLE!,
+    Key: { draftId },
+  }));
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/app/api/drafts/route.ts
+++ b/app/app/api/drafts/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, ScanCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+
+function getDynamo() {
+  return DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION ?? 'us-east-1' }));
+}
+
+export async function GET(req: NextRequest) {
+  let claims;
+  try {
+    claims = await requireAuth(req);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+
+  const dynamo = getDynamo();
+  const result = await dynamo.send(new ScanCommand({
+    TableName: process.env.DRAFTS_TABLE!,
+    FilterExpression: 'userId = :userId',
+    ExpressionAttributeValues: { ':userId': claims.sub },
+  }));
+
+  const drafts = (result.Items ?? []).sort((a, b) => {
+    const aTime = (a.updatedAt as string) ?? '';
+    const bTime = (b.updatedAt as string) ?? '';
+    return bTime.localeCompare(aTime);
+  });
+
+  return NextResponse.json({ drafts });
+}
+
+export async function POST(req: NextRequest) {
+  let claims;
+  try {
+    claims = await requireAuth(req);
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = await req.json();
+  } catch {
+    // empty body is valid for a new draft
+  }
+
+  const { from, to, cc, bcc, subject, body, attachmentKeys, inReplyToMessageId } = payload;
+
+  const draftId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const dynamo = getDynamo();
+  await dynamo.send(new PutCommand({
+    TableName: process.env.DRAFTS_TABLE!,
+    Item: {
+      draftId,
+      userId: claims.sub,
+      ...(from !== undefined ? { from } : {}),
+      ...(to !== undefined ? { to } : {}),
+      ...(cc !== undefined ? { cc } : {}),
+      ...(bcc !== undefined ? { bcc } : {}),
+      ...(subject !== undefined ? { subject } : {}),
+      ...(body !== undefined ? { body } : {}),
+      ...(attachmentKeys !== undefined ? { attachmentKeys } : {}),
+      ...(inReplyToMessageId !== undefined ? { inReplyToMessageId } : {}),
+      createdAt: now,
+      updatedAt: now,
+    },
+  }));
+
+  return NextResponse.json({ draftId }, { status: 201 });
+}


### PR DESCRIPTION
Adds GET /api/drafts (scan by userId, sorted newest-first), POST /api/drafts (create with UUID, stores all draft fields and userId), PUT /api/drafts/:id (upsert with ownership condition expression), and DELETE /api/drafts/:id (GET then verify ownership then delete, returning 403 on mismatch and 404 if not found).

closes #37