### PR TITLE
[feat]: Reply Composer component embedded in message detail (#38)

### DIFF
--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -127,14 +127,24 @@ describe('MessageDetail', () => {
     expect(downloadLinks).toHaveLength(2);
   });
 
-  test('shows reply notice on Reply click', async () => {
+  test('opens ReplyComposer on Reply click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
 
     await user.click(screen.getByRole('button', { name: /^reply$/i }));
 
-    await waitFor(() => {
-      expect(screen.getByRole('status')).toHaveTextContent(/reply coming soon/i);
-    });
+    expect(screen.getByTestId('reply-composer')).toBeInTheDocument();
+  });
+
+  test('opens ReplyComposer in replyAll mode on Reply All click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+
+    await user.click(screen.getByRole('button', { name: /reply all/i }));
+
+    expect(screen.getByTestId('reply-composer')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-cc')).toBeInTheDocument();
   });
 });

--- a/app/__tests__/components/messages/reply-composer.test.tsx
+++ b/app/__tests__/components/messages/reply-composer.test.tsx
@@ -1,0 +1,272 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReplyComposer } from '@/components/messages/reply-composer';
+
+const BASE_MESSAGE = {
+  messageId: 'msg-1',
+  subject: 'Hello there',
+  from: 'sender@external.com',
+  to: 'me@hermes.com',
+  cc: 'other@example.com',
+};
+
+const DEFAULT_PROPS = {
+  message: BASE_MESSAGE,
+  currentAddress: 'me@hermes.com',
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+async function advanceAutoSave() {
+  await act(async () => {
+    jest.advanceTimersByTime(10_000);
+  });
+}
+
+describe('ReplyComposer', () => {
+  describe('pre-filled fields', () => {
+    test('pre-fills From with currentAddress as read-only', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      const fromInput = screen.getByTestId('reply-from');
+      expect(fromInput).toHaveValue('me@hermes.com');
+      expect(fromInput).toBeDisabled();
+    });
+
+    test('pre-fills To with original sender', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      expect(screen.getByTestId('reply-to')).toHaveValue('sender@external.com');
+    });
+
+    test('does not show Cc field for plain Reply', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      expect(screen.queryByTestId('reply-cc')).not.toBeInTheDocument();
+    });
+
+    test('shows Cc field for Reply All', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} replyAll />);
+
+      expect(screen.getByTestId('reply-cc')).toBeInTheDocument();
+    });
+
+    test('pre-fills Cc for Reply All excluding currentAddress', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} replyAll />);
+
+      const ccInput = screen.getByTestId('reply-cc');
+      expect(ccInput).toHaveValue('other@example.com');
+      expect((ccInput as HTMLInputElement).value).not.toContain('me@hermes.com');
+    });
+
+    test('includes quoted body in textarea when quotedBody is provided', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} quotedBody="Original message text" />);
+
+      const textarea = screen.getByTestId('reply-body');
+      expect((textarea as HTMLTextAreaElement).value).toContain('Original message text');
+    });
+  });
+
+  describe('auto-save', () => {
+    test('shows Saving… indicator while fetch is in-flight', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}));
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.type(screen.getByTestId('reply-body'), 'Hello');
+      await advanceAutoSave();
+
+      expect(screen.getByTestId('save-status-saving')).toBeInTheDocument();
+    });
+
+    test('calls POST /api/drafts on first auto-save', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-abc' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.type(screen.getByTestId('reply-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+    });
+
+    test('shows Draft saved indicator after successful save', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-abc' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.type(screen.getByTestId('reply-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-status-saved')).toBeInTheDocument();
+      });
+    });
+
+    test('calls PUT /api/drafts/:id on subsequent auto-saves', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-existing' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} initialDraftId="draft-existing" />);
+
+      await user.type(screen.getByTestId('reply-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts/draft-existing',
+          expect.objectContaining({ method: 'PUT' }),
+        );
+      });
+    });
+  });
+
+  describe('send', () => {
+    test('calls POST /api/messages/:id/reply on Send click', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ messageId: 'new-msg' }) });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.click(screen.getByTestId('send-button'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/messages/msg-1/reply',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+    });
+
+    test('calls onClose after successful send', async () => {
+      const onClose = jest.fn();
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ messageId: 'new-msg' }) });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} onClose={onClose} />);
+
+      await user.click(screen.getByTestId('send-button'));
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    test('shows error message when send fails', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: 'Failed to send' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.click(screen.getByTestId('send-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('send-error')).toBeInTheDocument();
+      });
+    });
+
+    test('Send button is disabled when To field is empty', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} message={{ ...BASE_MESSAGE, from: undefined }} />);
+
+      expect(screen.getByTestId('send-button')).toBeDisabled();
+    });
+  });
+
+  describe('discard', () => {
+    test('calls DELETE /api/drafts/:id on discard when draftId exists', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} initialDraftId="draft-xyz" />);
+
+      await user.click(screen.getByTestId('discard-button'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts/draft-xyz',
+          expect.objectContaining({ method: 'DELETE' }),
+        );
+      });
+    });
+
+    test('calls onClose on discard without draft', async () => {
+      const onClose = jest.fn();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} onClose={onClose} />);
+
+      await user.click(screen.getByTestId('discard-button'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('attachments', () => {
+    test('shows attach button', () => {
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+      expect(screen.getByTestId('attach-button')).toBeInTheDocument();
+    });
+
+    test('uploads file and shows it in attachment list', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          s3Key: 'uploads/uuid/report.pdf',
+          filename: 'report.pdf',
+          contentType: 'application/pdf',
+          size: 1024,
+        }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      const file = new File(['content'], 'report.pdf', { type: 'application/pdf' });
+      await user.upload(screen.getByTestId('file-input'), file);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('attachment-list')).toBeInTheDocument();
+        expect(screen.getByText('report.pdf')).toBeInTheDocument();
+      });
+    });
+
+    test('removes attachment from list on remove click', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          s3Key: 'uploads/uuid/doc.pdf',
+          filename: 'doc.pdf',
+          contentType: 'application/pdf',
+          size: 512,
+        }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.upload(screen.getByTestId('file-input'), new File(['content'], 'doc.pdf', { type: 'application/pdf' }));
+      await waitFor(() => expect(screen.getByText('doc.pdf')).toBeInTheDocument());
+
+      await user.click(screen.getByTestId('remove-attachment-doc.pdf'));
+      expect(screen.queryByText('doc.pdf')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Download, Reply, ReplyAll, MailOpen } from 'lucide-react';
+import { ReplyComposer } from '@/components/messages/reply-composer';
 
 interface Attachment {
   filename: string;
@@ -21,6 +22,7 @@ interface Message {
   subject: string;
   receivedAt: string;
   isRead: boolean;
+  address?: string;
   from?: string;
   to?: string;
   cc?: string;
@@ -38,7 +40,7 @@ export function MessageDetail({ message }: MessageDetailProps) {
   const [htmlBody, setHtmlBody] = useState<string | null>(null);
   const [textBody, setTextBody] = useState<string | null>(null);
   const [isRead, setIsRead] = useState(message.isRead);
-  const [replyNotice, setReplyNotice] = useState<string | null>(null);
+  const [composerMode, setComposerMode] = useState<'reply' | 'replyAll' | null>(null);
 
   useEffect(() => {
     if (message.bodyHtmlUrl) {
@@ -87,8 +89,11 @@ export function MessageDetail({ message }: MessageDetailProps) {
   }
 
   function handleReply() {
-    setReplyNotice('Reply coming soon');
-    setTimeout(() => setReplyNotice(null), 3000);
+    setComposerMode('reply');
+  }
+
+  function handleReplyAll() {
+    setComposerMode('replyAll');
   }
 
   return (
@@ -112,7 +117,7 @@ export function MessageDetail({ message }: MessageDetailProps) {
                   <Reply className="h-3.5 w-3.5" />
                   Reply
                 </Button>
-                <Button size="sm" variant="outline" onClick={handleReply} className="gap-1">
+                <Button size="sm" variant="outline" onClick={handleReplyAll} className="gap-1">
                   <ReplyAll className="h-3.5 w-3.5" />
                   Reply All
                 </Button>
@@ -125,21 +130,15 @@ export function MessageDetail({ message }: MessageDetailProps) {
           </div>
         </CardHeader>
 
-        {replyNotice && (
-          <div className="mx-6 mb-3 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground" role="status">
-            {replyNotice}
-          </div>
-        )}
-
         <Separator />
 
         <CardContent className="pt-4">
-          <ScrollArea className="h-[500px] w-full rounded-md">
+          <ScrollArea className="h-125 w-full rounded-md">
             {htmlBody ? (
               <iframe
                 ref={iframeRef}
                 sandbox="allow-same-origin"
-                className="w-full min-h-[480px] border-0"
+                className="w-full min-h-120 border-0"
                 title="Email body"
                 data-testid="html-body-frame"
               />
@@ -175,6 +174,16 @@ export function MessageDetail({ message }: MessageDetailProps) {
             </ul>
           </CardContent>
         </Card>
+      )}
+
+      {composerMode && (
+        <ReplyComposer
+          message={message}
+          replyAll={composerMode === 'replyAll'}
+          currentAddress={message.address ?? message.to ?? ''}
+          quotedBody={textBody}
+          onClose={() => setComposerMode(null)}
+        />
       )}
     </div>
   );

--- a/app/components/messages/reply-composer.tsx
+++ b/app/components/messages/reply-composer.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Paperclip, Send, Trash2, X } from 'lucide-react';
+
+interface Message {
+  messageId: string;
+  subject: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+}
+
+interface UploadedAttachment {
+  filename: string;
+  s3Key: string;
+  contentType: string;
+  size: number;
+}
+
+interface ReplyComposerProps {
+  message: Message;
+  replyAll?: boolean;
+  currentAddress: string;
+  quotedBody?: string | null;
+  initialDraftId?: string | null;
+  initialBody?: string;
+  onClose: () => void;
+}
+
+type SaveStatus = 'idle' | 'saving' | 'saved';
+
+function buildCcForReplyAll(message: Message, currentAddress: string): string {
+  const addresses = [message.to, message.cc]
+    .filter(Boolean)
+    .join(', ')
+    .split(',')
+    .map((a) => a.trim())
+    .filter((a) => a && a.toLowerCase() !== currentAddress.toLowerCase());
+  return addresses.join(', ');
+}
+
+export function ReplyComposer({
+  message,
+  replyAll = false,
+  currentAddress,
+  quotedBody,
+  initialDraftId = null,
+  initialBody,
+  onClose,
+}: ReplyComposerProps) {
+  const originalSubject = message.subject ?? '';
+  const reSubject = originalSubject.toLowerCase().startsWith('re:')
+    ? originalSubject
+    : `Re: ${originalSubject}`;
+
+  const defaultBody = initialBody ?? (quotedBody
+    ? `\n\n--- Original Message ---\n${quotedBody}`
+    : '');
+
+  const [to, setTo] = useState(message.from ?? '');
+  const [cc, setCc] = useState(replyAll ? buildCcForReplyAll(message, currentAddress) : '');
+  const [body, setBody] = useState(defaultBody);
+  const [attachments, setAttachments] = useState<UploadedAttachment[]>([]);
+  const [draftId, setDraftId] = useState<string | null>(initialDraftId);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function saveDraft(draftPayload: Record<string, unknown>, existingDraftId: string | null): Promise<string | null> {
+    setSaveStatus('saving');
+    try {
+      if (existingDraftId) {
+        await fetch(`/api/drafts/${existingDraftId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(draftPayload),
+        });
+        setSavedAt(new Date());
+        setSaveStatus('saved');
+        return existingDraftId;
+      } else {
+        const res = await fetch('/api/drafts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(draftPayload),
+        });
+        if (!res.ok) {
+          setSaveStatus('idle');
+          return null;
+        }
+        const data = await res.json() as { draftId: string };
+        setDraftId(data.draftId);
+        setSavedAt(new Date());
+        setSaveStatus('saved');
+        return data.draftId;
+      }
+    } catch {
+      setSaveStatus('idle');
+      return existingDraftId;
+    }
+  }
+
+  function scheduleSave(currentDraftId: string | null, payload: Record<string, unknown>) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      saveDraft(payload, currentDraftId);
+    }, 10_000);
+  }
+
+  function handleBodyChange(value: string) {
+    setBody(value);
+    scheduleSave(draftId, {
+      from: currentAddress,
+      to,
+      cc: cc || undefined,
+      body: value,
+      attachmentKeys: attachments.map((a) => a.s3Key),
+      inReplyToMessageId: message.messageId,
+    });
+  }
+
+  function handleToChange(value: string) {
+    setTo(value);
+    scheduleSave(draftId, {
+      from: currentAddress,
+      to: value,
+      cc: cc || undefined,
+      body,
+      attachmentKeys: attachments.map((a) => a.s3Key),
+      inReplyToMessageId: message.messageId,
+    });
+  }
+
+  function handleCcChange(value: string) {
+    setCc(value);
+    scheduleSave(draftId, {
+      from: currentAddress,
+      to,
+      cc: value || undefined,
+      body,
+      attachmentKeys: attachments.map((a) => a.s3Key),
+      inReplyToMessageId: message.messageId,
+    });
+  }
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+
+    setIsUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/uploads', { method: 'POST', body: formData });
+      if (!res.ok) return;
+      const data = await res.json() as { s3Key: string; filename: string; contentType: string; size: number };
+      setAttachments((prev) => [...prev, { filename: data.filename, s3Key: data.s3Key, contentType: data.contentType, size: data.size }]);
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  function removeAttachment(s3Key: string) {
+    setAttachments((prev) => prev.filter((a) => a.s3Key !== s3Key));
+  }
+
+  async function handleSend() {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setIsSending(true);
+    setSendError(null);
+    try {
+      const res = await fetch(`/api/messages/${message.messageId}/reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: currentAddress,
+          to,
+          cc: cc || undefined,
+          body,
+          attachmentKeys: attachments.map((a) => a.s3Key),
+          draftId: draftId ?? undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setSendError(data.error ?? 'Failed to send reply');
+        return;
+      }
+      onClose();
+    } catch {
+      setSendError('Failed to send reply. Please try again.');
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handleDiscard() {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (draftId) {
+      await fetch(`/api/drafts/${draftId}`, { method: 'DELETE' }).catch(() => null);
+    }
+    onClose();
+  }
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  function formatSavedAt(date: Date) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+
+  return (
+    <Card data-testid="reply-composer">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">
+              {replyAll ? 'Reply All' : 'Reply'}
+            </span>
+            {saveStatus === 'saving' && (
+              <span className="text-xs text-muted-foreground" data-testid="save-status-saving">Saving…</span>
+            )}
+            {saveStatus === 'saved' && savedAt && (
+              <span className="text-xs text-muted-foreground" data-testid="save-status-saved">
+                Draft saved {formatSavedAt(savedAt)}
+              </span>
+            )}
+          </div>
+          <Button size="icon" variant="ghost" onClick={handleDiscard} aria-label="Discard reply">
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <div className="space-y-1">
+          <Label htmlFor="reply-from" className="text-xs text-muted-foreground">From</Label>
+          <Input
+            id="reply-from"
+            value={currentAddress}
+            readOnly
+            disabled
+            className="bg-muted"
+            data-testid="reply-from"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="reply-to" className="text-xs">To</Label>
+          <Input
+            id="reply-to"
+            value={to}
+            onChange={(e) => handleToChange(e.target.value)}
+            placeholder="recipient@example.com"
+            data-testid="reply-to"
+          />
+        </div>
+
+        {replyAll && (
+          <div className="space-y-1">
+            <Label htmlFor="reply-cc" className="text-xs">Cc</Label>
+            <Input
+              id="reply-cc"
+              value={cc}
+              onChange={(e) => handleCcChange(e.target.value)}
+              placeholder="cc@example.com"
+              data-testid="reply-cc"
+            />
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <Label htmlFor="reply-body" className="text-xs">Message</Label>
+          <Textarea
+            id="reply-body"
+            value={body}
+            onChange={(e) => handleBodyChange(e.target.value)}
+            placeholder="Write your reply…"
+            className="min-h-[160px] resize-y"
+            data-testid="reply-body"
+          />
+        </div>
+
+        {attachments.length > 0 && (
+          <ul className="space-y-1" data-testid="attachment-list">
+            {attachments.map((att) => (
+              <li key={att.s3Key} className="flex items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-sm">
+                <span className="truncate">{att.filename}</span>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-6 w-6 shrink-0"
+                  onClick={() => removeAttachment(att.s3Key)}
+                  aria-label={`Remove ${att.filename}`}
+                  data-testid={`remove-attachment-${att.filename}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {sendError && (
+          <p className="text-sm text-destructive" role="alert" data-testid="send-error">{sendError}</p>
+        )}
+
+        <div className="flex items-center justify-between pt-1">
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={handleFileSelect}
+              data-testid="file-input"
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              className="gap-1"
+              data-testid="attach-button"
+            >
+              <Paperclip className="h-3.5 w-3.5" />
+              {isUploading ? 'Uploading…' : 'Attach'}
+            </Button>
+            {replyAll && (
+              <Badge variant="secondary" className="text-xs">Reply All</Badge>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleDiscard}
+              data-testid="discard-button"
+            >
+              <Trash2 className="h-3.5 w-3.5 mr-1" />
+              Discard
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSend}
+              disabled={isSending || !to.trim()}
+              className="gap-1"
+              data-testid="send-button"
+            >
+              <Send className="h-3.5 w-3.5" />
+              {isSending ? 'Sending…' : 'Send'}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/ui/textarea.tsx
+++ b/app/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };


### PR DESCRIPTION
Adds ReplyComposer component (Card/Textarea/Input/Button/Label/Badge) that embeds below message detail on Reply/Reply All click. Pre-fills From (read-only), To, Subject (Re: prefix), and quoted body. Supports Reply All Cc field excluding currentAddress. Auto-saves draft with 10-second debounce (POST then PUT), showing Saving/Draft-saved indicators. File attachments upload via POST /api/uploads with per-file remove. Send calls POST /api/messages/:id/reply and closes on success. Discard calls DELETE /api/drafts/:id. Also adds Textarea shadcn/ui component and fixes legacy Tailwind arbitrary-value classes in message-detail.

closes #38