### PR TITLE
[feat]: Compose Sheet slide-over panel for new outbound emails (#39)

### DIFF
--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -4,10 +4,15 @@ import { Sidebar } from '@/components/layout/sidebar';
 
 const mockPush = jest.fn();
 const mockPathname = jest.fn().mockReturnValue('/');
+const mockOpenCompose = jest.fn();
 
 jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
   useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/components/compose-context', () => ({
+  useCompose: () => ({ openCompose: mockOpenCompose, closeCompose: jest.fn(), isOpen: false, initialData: null }),
 }));
 
 jest.mock('@/components/ui/tooltip', () => ({
@@ -26,6 +31,7 @@ beforeEach(() => {
   global.fetch = jest.fn();
   mockPathname.mockReturnValue('/');
   mockPush.mockReset();
+  mockOpenCompose.mockReset();
 });
 
 afterEach(() => {
@@ -54,6 +60,15 @@ describe('Sidebar', () => {
     expect(screen.getByText('Compose')).toBeInTheDocument();
     expect(screen.getByText('Drafts')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  test('Compose button opens compose sheet via context', async () => {
+    const user = userEvent.setup();
+    render(<Sidebar addresses={ADDRESSES} />);
+
+    await user.click(screen.getByTestId('compose-button'));
+
+    expect(mockOpenCompose).toHaveBeenCalledTimes(1);
   });
 
   test('calls sign out on button click', async () => {

--- a/app/__tests__/components/messages/compose-sheet.test.tsx
+++ b/app/__tests__/components/messages/compose-sheet.test.tsx
@@ -1,0 +1,314 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposeSheet } from '@/components/messages/compose-sheet';
+import { ComposeProvider } from '@/components/compose-context';
+import { useCompose } from '@/components/compose-context';
+
+jest.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="sheet-root">{children}</div> : null,
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="sheet-content">{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  SheetClose: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetPortal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetOverlay: () => null,
+  SheetFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  SheetTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const ACTIVE_ADDRESSES = [
+  { email: 'me@hermes.com', domain: 'hermes.com', status: 'active' },
+  { email: 'work@hermes.com', domain: 'hermes.com', status: 'active' },
+  { email: 'deleted@hermes.com', domain: 'hermes.com', status: 'deleted' },
+];
+
+function OpenComposeButton({ data }: { data?: Parameters<ReturnType<typeof useCompose>['openCompose']>[0] }) {
+  const { openCompose } = useCompose();
+  return <button onClick={() => openCompose(data)} data-testid="open-compose">Open</button>;
+}
+
+function TestWrapper({ initialData }: { initialData?: Parameters<ReturnType<typeof useCompose>['openCompose']>[0] }) {
+  return (
+    <ComposeProvider>
+      <OpenComposeButton data={initialData} />
+      <ComposeSheet addresses={ACTIVE_ADDRESSES} />
+    </ComposeProvider>
+  );
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+async function advanceAutoSave() {
+  await act(async () => {
+    jest.advanceTimersByTime(10_000);
+  });
+}
+
+describe('ComposeSheet', () => {
+  describe('From dropdown', () => {
+    test('shows only active (non-deleted) addresses in From dropdown', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+
+      expect(screen.getByTestId('compose-from')).toBeInTheDocument();
+      expect(screen.queryByText('deleted@hermes.com')).not.toBeInTheDocument();
+    });
+
+    test('defaults From to first active address', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+
+      expect(screen.getByTestId('compose-from')).toHaveTextContent('me@hermes.com');
+    });
+  });
+
+  describe('email validation', () => {
+    test('shows validation error for invalid email in To field', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'not-an-email');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+      });
+    });
+
+    test('shows validation error for invalid email in Cc field', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'valid@example.com');
+      await user.type(screen.getByTestId('compose-cc'), 'bad-email');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+      });
+    });
+
+    test('accepts comma-separated valid emails in To field', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ messageId: 'new-msg' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'a@example.com, b@example.com');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/valid email/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('auto-save', () => {
+    test('shows Saving… indicator while save is in-flight', async () => {
+      (global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}));
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await advanceAutoSave();
+
+      expect(screen.getByTestId('save-status-saving')).toBeInTheDocument();
+    });
+
+    test('calls POST /api/drafts on first auto-save', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-new' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+    });
+
+    test('shows Draft saved indicator after successful save', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-new' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-status-saved')).toBeInTheDocument();
+      });
+    });
+
+    test('calls PUT /api/drafts/:id on subsequent saves when initialDraftId is provided', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-existing' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper initialData={{ draftId: 'draft-existing' }} />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await advanceAutoSave();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts/draft-existing',
+          expect.objectContaining({ method: 'PUT' }),
+        );
+      });
+    });
+  });
+
+  describe('send', () => {
+    test('calls POST /api/messages on send', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ messageId: 'new-msg' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'recipient@example.com');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/messages',
+          expect.objectContaining({ method: 'POST' }),
+        );
+      });
+    });
+
+    test('closes sheet after successful send', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ messageId: 'new-msg' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'recipient@example.com');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('compose-form')).not.toBeInTheDocument();
+      });
+    });
+
+    test('shows error when send fails', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: 'Send failed' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-to'), 'recipient@example.com');
+      await user.type(screen.getByTestId('compose-subject'), 'Hello');
+      await user.click(screen.getByTestId('compose-send-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('compose-send-error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('discard', () => {
+    test('calls DELETE /api/drafts/:id when draftId exists', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper initialData={{ draftId: 'draft-abc' }} />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.click(screen.getByTestId('compose-discard-button'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts/draft-abc',
+          expect.objectContaining({ method: 'DELETE' }),
+        );
+      });
+    });
+
+    test('closes sheet on discard without draft', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      expect(screen.getByTestId('compose-form')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('compose-discard-button'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('compose-form')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('restoring draft fields', () => {
+    test('restores all fields from initialData', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(
+        <TestWrapper
+          initialData={{
+            draftId: 'draft-1',
+            from: 'me@hermes.com',
+            to: 'them@example.com',
+            subject: 'Draft subject',
+            body: 'Draft body text',
+          }}
+        />,
+      );
+
+      await user.click(screen.getByTestId('open-compose'));
+
+      expect(screen.getByTestId('compose-to')).toHaveValue('them@example.com');
+      expect(screen.getByTestId('compose-subject')).toHaveValue('Draft subject');
+      expect(screen.getByTestId('compose-body')).toHaveValue('Draft body text');
+    });
+  });
+});

--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -2,6 +2,8 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { Sidebar } from '@/components/layout/sidebar';
 import { Topbar } from '@/components/layout/topbar';
+import { ComposeProvider } from '@/components/compose-context';
+import { ComposeSheet } from '@/components/messages/compose-sheet';
 
 interface Address {
   email: string;
@@ -38,12 +40,15 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const addresses = await getAddresses();
 
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar addresses={addresses} />
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <Topbar />
-        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+    <ComposeProvider>
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar addresses={addresses} />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <Topbar />
+          <main className="flex-1 overflow-y-auto p-6">{children}</main>
+        </div>
       </div>
-    </div>
+      <ComposeSheet addresses={addresses} />
+    </ComposeProvider>
   );
 }

--- a/app/components/compose-context.tsx
+++ b/app/components/compose-context.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+export interface ComposeInitialData {
+  draftId?: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  body?: string;
+  attachmentKeys?: string[];
+}
+
+interface ComposeContextValue {
+  isOpen: boolean;
+  initialData: ComposeInitialData | null;
+  openCompose: (data?: ComposeInitialData) => void;
+  closeCompose: () => void;
+}
+
+const ComposeContext = createContext<ComposeContextValue | null>(null);
+
+export function useCompose() {
+  const ctx = useContext(ComposeContext);
+  if (!ctx) throw new Error('useCompose must be used within ComposeProvider');
+  return ctx;
+}
+
+interface ComposeProviderProps {
+  children: ReactNode;
+}
+
+export function ComposeProvider({ children }: ComposeProviderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialData, setInitialData] = useState<ComposeInitialData | null>(null);
+
+  function openCompose(data?: ComposeInitialData) {
+    setInitialData(data ?? null);
+    setIsOpen(true);
+  }
+
+  function closeCompose() {
+    setIsOpen(false);
+    setInitialData(null);
+  }
+
+  return (
+    <ComposeContext.Provider value={{ isOpen, initialData, openCompose, closeCompose }}>
+      {children}
+    </ComposeContext.Provider>
+  );
+}

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -6,8 +6,9 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useCompose } from '@/components/compose-context';
 
-import { Mail, FileText, Settings, LogOut, PenSquare, AtSign, Globe } from 'lucide-react';
+import { Mail, FileText, Settings, LogOut, PenSquare, Globe } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -25,6 +26,7 @@ interface SidebarProps {
 export function Sidebar({ addresses }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
+  const { openCompose } = useCompose();
 
   async function handleSignOut() {
     await fetch('/api/auth/signout', { method: 'POST' });
@@ -39,11 +41,15 @@ export function Sidebar({ addresses }: SidebarProps) {
         </div>
 
         <div className="flex flex-col gap-1 p-3">
-          <Button asChild variant="default" size="sm" className="w-full justify-start gap-2">
-            <Link href="/compose">
-              <PenSquare className="h-4 w-4" />
-              Compose
-            </Link>
+          <Button
+            variant="default"
+            size="sm"
+            className="w-full justify-start gap-2"
+            onClick={() => openCompose()}
+            data-testid="compose-button"
+          >
+            <PenSquare className="h-4 w-4" />
+            Compose
           </Button>
         </div>
 

--- a/app/components/messages/compose-sheet.tsx
+++ b/app/components/messages/compose-sheet.tsx
@@ -1,0 +1,501 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Paperclip, Send, Trash2, X } from 'lucide-react';
+import { useCompose, type ComposeInitialData } from '@/components/compose-context';
+
+interface Address {
+  email: string;
+  status: string;
+}
+
+interface UploadedAttachment {
+  filename: string;
+  s3Key: string;
+  contentType: string;
+  size: number;
+}
+
+function validateEmails(value: string): boolean {
+  if (!value.trim()) return true;
+  const emails = value.split(',').map((e) => e.trim()).filter(Boolean);
+  return emails.every((e) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e));
+}
+
+const composeSchema = z.object({
+  from: z.string().min(1, 'From is required'),
+  to: z
+    .string()
+    .min(1, 'To is required')
+    .refine(validateEmails, 'Enter valid email addresses (comma-separated)'),
+  cc: z
+    .string()
+    .refine(validateEmails, 'Enter valid email addresses (comma-separated)')
+    .optional()
+    .or(z.literal('')),
+  bcc: z
+    .string()
+    .refine(validateEmails, 'Enter valid email addresses (comma-separated)')
+    .optional()
+    .or(z.literal('')),
+  subject: z.string().min(1, 'Subject is required'),
+  body: z.string().default(''),
+});
+
+type ComposeFormValues = z.infer<typeof composeSchema>;
+
+type SaveStatus = 'idle' | 'saving' | 'saved';
+
+interface ComposeSheetInnerProps {
+  addresses: Address[];
+  initialData: ComposeInitialData | null;
+  onClose: () => void;
+}
+
+function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInnerProps) {
+  const activeAddresses = addresses.filter((a) => a.status !== 'deleted');
+
+  const form = useForm<ComposeFormValues>({
+    resolver: zodResolver(composeSchema),
+    defaultValues: {
+      from: initialData?.from ?? activeAddresses[0]?.email ?? '',
+      to: initialData?.to ?? '',
+      cc: initialData?.cc ?? '',
+      bcc: initialData?.bcc ?? '',
+      subject: initialData?.subject ?? '',
+      body: initialData?.body ?? '',
+    },
+  });
+
+  const [attachments, setAttachments] = useState<UploadedAttachment[]>([]);
+  const [draftId, setDraftId] = useState<string | null>(initialData?.draftId ?? null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const draftIdRef = useRef<string | null>(draftId);
+
+  useEffect(() => {
+    draftIdRef.current = draftId;
+  }, [draftId]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  async function saveDraft(payload: Record<string, unknown>, existingDraftId: string | null): Promise<string | null> {
+    setSaveStatus('saving');
+    try {
+      if (existingDraftId) {
+        await fetch(`/api/drafts/${existingDraftId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        setSavedAt(new Date());
+        setSaveStatus('saved');
+        return existingDraftId;
+      } else {
+        const res = await fetch('/api/drafts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          setSaveStatus('idle');
+          return null;
+        }
+        const data = await res.json() as { draftId: string };
+        setDraftId(data.draftId);
+        setSavedAt(new Date());
+        setSaveStatus('saved');
+        return data.draftId;
+      }
+    } catch {
+      setSaveStatus('idle');
+      return existingDraftId;
+    }
+  }
+
+  function scheduleSave(payload: Record<string, unknown>) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      saveDraft(payload, draftIdRef.current);
+    }, 10_000);
+  }
+
+  function buildPayload(values: Partial<ComposeFormValues>) {
+    const current = form.getValues();
+    return {
+      from: values.from ?? current.from,
+      to: values.to ?? current.to,
+      cc: (values.cc ?? current.cc) || undefined,
+      bcc: (values.bcc ?? current.bcc) || undefined,
+      subject: values.subject ?? current.subject,
+      body: values.body ?? current.body,
+      attachmentKeys: attachments.map((a) => a.s3Key),
+    };
+  }
+
+  function handleFieldChange(field: keyof ComposeFormValues, value: string) {
+    scheduleSave(buildPayload({ [field]: value }));
+  }
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = '';
+    setIsUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/uploads', { method: 'POST', body: formData });
+      if (!res.ok) return;
+      const data = await res.json() as { s3Key: string; filename: string; contentType: string; size: number };
+      setAttachments((prev) => [...prev, { filename: data.filename, s3Key: data.s3Key, contentType: data.contentType, size: data.size }]);
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  function removeAttachment(s3Key: string) {
+    setAttachments((prev) => prev.filter((a) => a.s3Key !== s3Key));
+  }
+
+  async function handleSend(values: ComposeFormValues) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    setIsSending(true);
+    setSendError(null);
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: values.from,
+          to: values.to,
+          cc: values.cc || undefined,
+          bcc: values.bcc || undefined,
+          subject: values.subject,
+          body: values.body,
+          attachmentKeys: attachments.map((a) => a.s3Key),
+          draftId: draftIdRef.current ?? undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json() as { error?: string };
+        setSendError(data.error ?? 'Failed to send email');
+        return;
+      }
+      onClose();
+    } catch {
+      setSendError('Failed to send email. Please try again.');
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handleDiscard() {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (draftIdRef.current) {
+      await fetch(`/api/drafts/${draftIdRef.current}`, { method: 'DELETE' }).catch(() => null);
+    }
+    onClose();
+  }
+
+  function formatSavedAt(date: Date) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <SheetHeader className="shrink-0 pb-4">
+        <div className="flex items-center justify-between pr-8">
+          <SheetTitle>New Message</SheetTitle>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            {saveStatus === 'saving' && (
+              <span data-testid="save-status-saving">Saving…</span>
+            )}
+            {saveStatus === 'saved' && savedAt && (
+              <span data-testid="save-status-saved">
+                Draft saved {formatSavedAt(savedAt)}
+              </span>
+            )}
+          </div>
+        </div>
+      </SheetHeader>
+
+      <div className="flex-1 overflow-y-auto px-6 pb-6">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSend)}
+            className="space-y-4"
+            data-testid="compose-form"
+          >
+            <FormField
+              control={form.control}
+              name="from"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs text-muted-foreground">From</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(val) => {
+                      field.onChange(val);
+                      handleFieldChange('from', val);
+                    }}
+                  >
+                    <FormControl>
+                      <SelectTrigger data-testid="compose-from">
+                        <SelectValue placeholder="Select sender" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {activeAddresses.map((addr) => (
+                        <SelectItem key={addr.email} value={addr.email}>
+                          {addr.email}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="to"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">To</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="recipient@example.com"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        handleFieldChange('to', e.target.value);
+                      }}
+                      data-testid="compose-to"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="cc"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs text-muted-foreground">Cc</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="cc@example.com"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        handleFieldChange('cc', e.target.value);
+                      }}
+                      data-testid="compose-cc"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bcc"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs text-muted-foreground">Bcc</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="bcc@example.com"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        handleFieldChange('bcc', e.target.value);
+                      }}
+                      data-testid="compose-bcc"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="subject"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Subject</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="Subject"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        handleFieldChange('subject', e.target.value);
+                      }}
+                      data-testid="compose-subject"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="body"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Message</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="Write your message…"
+                      className="min-h-[200px] resize-y"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        handleFieldChange('body', e.target.value);
+                      }}
+                      data-testid="compose-body"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {attachments.length > 0 && (
+              <ul className="space-y-1" data-testid="compose-attachment-list">
+                {attachments.map((att) => (
+                  <li
+                    key={att.s3Key}
+                    className="flex items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-sm"
+                  >
+                    <span className="truncate">{att.filename}</span>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className="h-6 w-6 shrink-0"
+                      onClick={() => removeAttachment(att.s3Key)}
+                      aria-label={`Remove ${att.filename}`}
+                      data-testid={`remove-attachment-${att.filename}`}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {sendError && (
+              <p className="text-sm text-destructive" role="alert" data-testid="compose-send-error">
+                {sendError}
+              </p>
+            )}
+
+            <div className="flex items-center justify-between pt-1">
+              <div className="flex items-center gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  className="hidden"
+                  onChange={handleFileSelect}
+                  data-testid="compose-file-input"
+                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isUploading}
+                  className="gap-1"
+                  data-testid="compose-attach-button"
+                >
+                  <Paperclip className="h-3.5 w-3.5" />
+                  {isUploading ? 'Uploading…' : 'Attach'}
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleDiscard}
+                  data-testid="compose-discard-button"
+                >
+                  <Trash2 className="h-3.5 w-3.5 mr-1" />
+                  Discard
+                </Button>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={isSending}
+                  className="gap-1"
+                  data-testid="compose-send-button"
+                >
+                  <Send className="h-3.5 w-3.5" />
+                  {isSending ? 'Sending…' : 'Send'}
+                </Button>
+              </div>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}
+
+interface ComposeSheetProps {
+  addresses: Address[];
+}
+
+export function ComposeSheet({ addresses }: ComposeSheetProps) {
+  const { isOpen, initialData, closeCompose } = useCompose();
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => { if (!open) closeCompose(); }}>
+      <SheetContent data-testid="compose-sheet">
+        {isOpen && (
+          <ComposeSheetInner
+            addresses={addresses}
+            initialData={initialData}
+            onClose={closeCompose}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = DialogPrimitive.Root
+const SheetTrigger = DialogPrimitive.Trigger
+const SheetClose = DialogPrimitive.Close
+const SheetPortal = DialogPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+))
+SheetOverlay.displayName = "SheetOverlay"
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-y-0 right-0 z-50 flex h-full w-full flex-col border-l bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = "SheetContent"
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 p-6 pb-0", className)} {...props} />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse gap-2 p-6 pt-0 sm:flex-row sm:justify-end", className)} {...props} />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = "SheetTitle"
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = "SheetDescription"
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
Adds ComposeSheet component with shadcn Sheet, From select (active addresses only), To/Cc/Bcc email validation via zod/react-hook-form, auto-save draft (10s debounce), file attachments, send via POST /api/messages, and discard via DELETE /api/drafts. Adds ComposeProvider context so sidebar Compose button and drafts list can open the sheet from anywhere in the app layout.

closes #39