### PR TITLE
[feat]: Drafts list page with compose and reply draft resume (#40)

### DIFF
--- a/app/__tests__/components/drafts/drafts-list.test.tsx
+++ b/app/__tests__/components/drafts/drafts-list.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DraftsList } from '@/components/drafts/drafts-list';
+
+const mockPush = jest.fn();
+const mockOpenCompose = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/components/compose-context', () => ({
+  useCompose: () => ({ openCompose: mockOpenCompose, closeCompose: jest.fn(), isOpen: false, initialData: null }),
+}));
+
+const COMPOSE_DRAFT = {
+  draftId: 'draft-compose-1',
+  to: 'recipient@example.com',
+  subject: 'Hello world',
+  body: 'Draft body',
+  from: 'me@hermes.com',
+  updatedAt: '2026-05-10T10:00:00.000Z',
+};
+
+const REPLY_DRAFT = {
+  draftId: 'draft-reply-1',
+  to: 'sender@external.com',
+  subject: 'Re: Original subject',
+  body: 'My reply',
+  from: 'me@hermes.com',
+  inReplyToMessageId: 'msg-original-123',
+  updatedAt: '2026-05-10T11:00:00.000Z',
+};
+
+const NO_SUBJECT_DRAFT = {
+  draftId: 'draft-no-subject',
+  to: 'someone@example.com',
+  from: 'me@hermes.com',
+  updatedAt: '2026-05-10T09:00:00.000Z',
+};
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockOpenCompose.mockReset();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DraftsList', () => {
+  test('shows empty state when no drafts', () => {
+    render(<DraftsList drafts={[]} />);
+    expect(screen.getByTestId('drafts-empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/no drafts saved yet/i)).toBeInTheDocument();
+  });
+
+  test('renders draft rows when drafts exist', () => {
+    render(<DraftsList drafts={[COMPOSE_DRAFT, REPLY_DRAFT]} />);
+    expect(screen.getByTestId('drafts-list')).toBeInTheDocument();
+    expect(screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`draft-row-${REPLY_DRAFT.draftId}`)).toBeInTheDocument();
+  });
+
+  test('shows subject for drafts with subject', () => {
+    render(<DraftsList drafts={[COMPOSE_DRAFT]} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+  });
+
+  test('shows "No subject" for drafts without subject', () => {
+    render(<DraftsList drafts={[NO_SUBJECT_DRAFT]} />);
+    expect(screen.getByText(/no subject/i)).toBeInTheDocument();
+  });
+
+  test('shows recipient address in To column', () => {
+    render(<DraftsList drafts={[COMPOSE_DRAFT]} />);
+    expect(screen.getByText('recipient@example.com')).toBeInTheDocument();
+  });
+
+  test('shows Reply badge for reply drafts', () => {
+    render(<DraftsList drafts={[REPLY_DRAFT]} />);
+    expect(screen.getByText('Reply')).toBeInTheDocument();
+  });
+
+  test('shows New badge for new composition drafts', () => {
+    render(<DraftsList drafts={[COMPOSE_DRAFT]} />);
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  test('clicking new composition draft opens Compose Sheet with restored fields', async () => {
+    const user = userEvent.setup();
+    render(<DraftsList drafts={[COMPOSE_DRAFT]} />);
+
+    await user.click(screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`));
+
+    expect(mockOpenCompose).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftId: COMPOSE_DRAFT.draftId,
+        from: COMPOSE_DRAFT.from,
+        to: COMPOSE_DRAFT.to,
+        subject: COMPOSE_DRAFT.subject,
+        body: COMPOSE_DRAFT.body,
+      }),
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  test('clicking reply draft navigates to message with draftId and mode params', async () => {
+    const user = userEvent.setup();
+    render(<DraftsList drafts={[REPLY_DRAFT]} />);
+
+    await user.click(screen.getByTestId(`draft-row-${REPLY_DRAFT.draftId}`));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining(REPLY_DRAFT.inReplyToMessageId),
+    );
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining(`draftId=${REPLY_DRAFT.draftId}`),
+    );
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining('mode=reply'),
+    );
+    expect(mockOpenCompose).not.toHaveBeenCalled();
+  });
+});

--- a/app/app/(app)/drafts/page.tsx
+++ b/app/app/(app)/drafts/page.tsx
@@ -1,0 +1,46 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { DraftsList } from '@/components/drafts/drafts-list';
+
+interface Draft {
+  draftId: string;
+  from?: string;
+  to?: string;
+  subject?: string;
+  body?: string;
+  cc?: string;
+  bcc?: string;
+  attachmentKeys?: string[];
+  inReplyToMessageId?: string;
+  updatedAt: string;
+}
+
+async function getDrafts(): Promise<Draft[]> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('access_token')?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/drafts`, {
+    headers: { Cookie: `access_token=${token}` },
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login');
+  }
+
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  return data.drafts ?? [];
+}
+
+export default async function DraftsPage() {
+  const drafts = await getDrafts();
+
+  return <DraftsList drafts={drafts} />;
+}

--- a/app/app/(app)/inbox/[address]/[messageId]/page.tsx
+++ b/app/app/(app)/inbox/[address]/[messageId]/page.tsx
@@ -50,15 +50,23 @@ async function getMessage(id: string): Promise<Message | null> {
 
 interface Props {
   params: Promise<{ address: string; messageId: string }>;
+  searchParams: Promise<{ draftId?: string; mode?: string }>;
 }
 
-export default async function MessageDetailPage({ params }: Props) {
+export default async function MessageDetailPage({ params, searchParams }: Props) {
   const { messageId } = await params;
+  const { draftId, mode } = await searchParams;
   const message = await getMessage(messageId);
 
   if (!message) {
     notFound();
   }
 
-  return <MessageDetail message={message} />;
+  return (
+    <MessageDetail
+      message={message}
+      initialDraftId={draftId}
+      initialComposerMode={mode === 'replyAll' ? 'replyAll' : mode === 'reply' ? 'reply' : undefined}
+    />
+  );
 }

--- a/app/components/drafts/drafts-list.tsx
+++ b/app/components/drafts/drafts-list.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { FileText } from 'lucide-react';
+import { useCompose } from '@/components/compose-context';
+
+interface Draft {
+  draftId: string;
+  from?: string;
+  to?: string;
+  subject?: string;
+  body?: string;
+  cc?: string;
+  bcc?: string;
+  attachmentKeys?: string[];
+  inReplyToMessageId?: string;
+  updatedAt: string;
+}
+
+interface DraftsListProps {
+  drafts: Draft[];
+}
+
+export function DraftsList({ drafts }: DraftsListProps) {
+  const router = useRouter();
+  const { openCompose } = useCompose();
+
+  function handleDraftClick(draft: Draft) {
+    if (draft.inReplyToMessageId) {
+      const address = encodeURIComponent(draft.from ?? '');
+      const mode = 'reply';
+      router.push(
+        `/inbox/${address}/${encodeURIComponent(draft.inReplyToMessageId)}?draftId=${draft.draftId}&mode=${mode}`,
+      );
+    } else {
+      openCompose({
+        draftId: draft.draftId,
+        from: draft.from,
+        to: draft.to,
+        cc: draft.cc,
+        bcc: draft.bcc,
+        subject: draft.subject,
+        body: draft.body,
+        attachmentKeys: draft.attachmentKeys,
+      });
+    }
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-3 py-20 text-center"
+        data-testid="drafts-empty-state"
+      >
+        <FileText className="h-10 w-10 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">No drafts saved yet.</p>
+        <p className="text-xs text-muted-foreground">
+          Drafts are saved automatically as you compose or reply.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="drafts-list">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Subject</TableHead>
+            <TableHead>To</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead className="text-right">Last saved</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {drafts.map((draft) => (
+            <TableRow
+              key={draft.draftId}
+              className="cursor-pointer hover:bg-accent/50"
+              onClick={() => handleDraftClick(draft)}
+              data-testid={`draft-row-${draft.draftId}`}
+            >
+              <TableCell>
+                {draft.subject ? (
+                  <span className="font-medium">{draft.subject}</span>
+                ) : (
+                  <span className="text-muted-foreground italic">No subject</span>
+                )}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {draft.to ?? '—'}
+              </TableCell>
+              <TableCell>
+                {draft.inReplyToMessageId ? (
+                  <Badge variant="secondary" className="text-xs">Reply</Badge>
+                ) : (
+                  <Badge variant="outline" className="text-xs">New</Badge>
+                )}
+              </TableCell>
+              <TableCell className="text-right text-sm text-muted-foreground">
+                {new Date(draft.updatedAt).toLocaleString([], {
+                  month: 'short',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -33,14 +33,16 @@ interface Message {
 
 interface MessageDetailProps {
   message: Message;
+  initialDraftId?: string;
+  initialComposerMode?: 'reply' | 'replyAll';
 }
 
-export function MessageDetail({ message }: MessageDetailProps) {
+export function MessageDetail({ message, initialDraftId, initialComposerMode }: MessageDetailProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [htmlBody, setHtmlBody] = useState<string | null>(null);
   const [textBody, setTextBody] = useState<string | null>(null);
   const [isRead, setIsRead] = useState(message.isRead);
-  const [composerMode, setComposerMode] = useState<'reply' | 'replyAll' | null>(null);
+  const [composerMode, setComposerMode] = useState<'reply' | 'replyAll' | null>(initialComposerMode ?? null);
 
   useEffect(() => {
     if (message.bodyHtmlUrl) {
@@ -182,6 +184,7 @@ export function MessageDetail({ message }: MessageDetailProps) {
           replyAll={composerMode === 'replyAll'}
           currentAddress={message.address ?? message.to ?? ''}
           quotedBody={textBody}
+          initialDraftId={initialDraftId}
           onClose={() => setComposerMode(null)}
         />
       )}


### PR DESCRIPTION
Adds /drafts page with DraftsList component showing all saved drafts in a Table. Clicking a new composition draft opens ComposeSheet with all fields restored. Clicking a reply draft navigates to the message and auto-opens ReplyComposer with the draft pre-loaded via draftId and mode query params. Shows empty state when no drafts exist.

closes #40