### PR TITLE
[feat]: domain onboarding API — setup and status endpoints (#92)

### DIFF
--- a/app/__tests__/app/api/domains/[domain]/status.test.ts
+++ b/app/__tests__/app/api/domains/[domain]/status.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: jest.fn(),
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(msg: string, status = 401) {
+      super(msg);
+      this.status = status;
+    }
+  },
+}));
+
+const mockSesSend = jest.fn();
+
+jest.mock('@aws-sdk/client-ses', () => ({
+  SESClient: jest.fn().mockImplementation(() => ({ send: mockSesSend })),
+  GetIdentityVerificationAttributesCommand: jest.fn((p: unknown) => ({
+    _type: 'get-verify-attrs',
+    ...((p as object) ?? {}),
+  })),
+  GetIdentityDkimAttributesCommand: jest.fn((p: unknown) => ({
+    _type: 'get-dkim-attrs',
+    ...((p as object) ?? {}),
+  })),
+}));
+
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+import { GET } from '@/app/api/domains/[domain]/status/route';
+
+const mockRequireAuth = requireAuth as jest.Mock;
+
+function makeReq(domain: string) {
+  return new NextRequest(`http://localhost/api/domains/${domain}/status`);
+}
+
+function makeParams(domain: string) {
+  return { params: Promise.resolve({ domain }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/domains/:domain/status', () => {
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await GET(makeReq('example.com'), makeParams('example.com'));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Missing authentication token');
+    expect(mockSesSend).not.toHaveBeenCalled();
+  });
+
+  test('returns combined SES and DKIM Verified status', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend
+      .mockResolvedValueOnce({
+        VerificationAttributes: { 'example.com': { VerificationStatus: 'Success' } },
+      })
+      .mockResolvedValueOnce({
+        DkimAttributes: { 'example.com': { DkimVerificationStatus: 'Success' } },
+      });
+
+    const res = await GET(makeReq('example.com'), makeParams('example.com'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ domain: 'example.com', ses: 'Verified', dkim: 'Verified' });
+  });
+
+  test('returns Pending when both SES and DKIM are pending', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend
+      .mockResolvedValueOnce({
+        VerificationAttributes: { 'example.com': { VerificationStatus: 'Pending' } },
+      })
+      .mockResolvedValueOnce({
+        DkimAttributes: { 'example.com': { DkimVerificationStatus: 'Pending' } },
+      });
+
+    const res = await GET(makeReq('example.com'), makeParams('example.com'));
+    const body = await res.json();
+
+    expect(body).toEqual({ domain: 'example.com', ses: 'Pending', dkim: 'Pending' });
+  });
+
+  test('returns Failed when SES status is Failed', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend
+      .mockResolvedValueOnce({
+        VerificationAttributes: { 'example.com': { VerificationStatus: 'Failed' } },
+      })
+      .mockResolvedValueOnce({
+        DkimAttributes: { 'example.com': { DkimVerificationStatus: 'Pending' } },
+      });
+
+    const res = await GET(makeReq('example.com'), makeParams('example.com'));
+    const body = await res.json();
+
+    expect(body.ses).toBe('Failed');
+    expect(body.dkim).toBe('Pending');
+  });
+
+  test('maps TemporaryFailure to Failed', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend
+      .mockResolvedValueOnce({
+        VerificationAttributes: {
+          'example.com': { VerificationStatus: 'TemporaryFailure' },
+        },
+      })
+      .mockResolvedValueOnce({
+        DkimAttributes: {
+          'example.com': { DkimVerificationStatus: 'TemporaryFailure' },
+        },
+      });
+
+    const res = await GET(makeReq('example.com'), makeParams('example.com'));
+    const body = await res.json();
+
+    expect(body.ses).toBe('Failed');
+    expect(body.dkim).toBe('Failed');
+  });
+
+  test('returns Pending when domain not found in SES response', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend
+      .mockResolvedValueOnce({ VerificationAttributes: {} })
+      .mockResolvedValueOnce({ DkimAttributes: {} });
+
+    const res = await GET(makeReq('unknown.com'), makeParams('unknown.com'));
+    const body = await res.json();
+
+    expect(body).toEqual({ domain: 'unknown.com', ses: 'Pending', dkim: 'Pending' });
+  });
+});

--- a/app/__tests__/app/api/domains/setup/route.test.ts
+++ b/app/__tests__/app/api/domains/setup/route.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: jest.fn(),
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(msg: string, status = 401) {
+      super(msg);
+      this.status = status;
+    }
+  },
+}));
+
+const mockSesSend = jest.fn();
+const mockR53Send = jest.fn();
+
+jest.mock('@aws-sdk/client-ses', () => ({
+  SESClient: jest.fn().mockImplementation(() => ({ send: mockSesSend })),
+  GetIdentityVerificationAttributesCommand: jest.fn((p: unknown) => ({
+    _type: 'get-attrs',
+    ...((p as object) ?? {}),
+  })),
+  VerifyDomainIdentityCommand: jest.fn((p: unknown) => ({
+    _type: 'verify-identity',
+    ...((p as object) ?? {}),
+  })),
+  VerifyDomainDkimCommand: jest.fn((p: unknown) => ({
+    _type: 'verify-dkim',
+    ...((p as object) ?? {}),
+  })),
+}));
+
+jest.mock('@aws-sdk/client-route-53', () => ({
+  Route53Client: jest.fn().mockImplementation(() => ({ send: mockR53Send })),
+  ListHostedZonesByNameCommand: jest.fn((p: unknown) => ({
+    _type: 'list-zones',
+    ...((p as object) ?? {}),
+  })),
+  ChangeResourceRecordSetsCommand: jest.fn((p: unknown) => ({
+    _type: 'change-records',
+    ...((p as object) ?? {}),
+  })),
+  ChangeAction: { CREATE: 'CREATE' },
+  RRType: { CNAME: 'CNAME', MX: 'MX', TXT: 'TXT' },
+}));
+
+import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+import { POST } from '@/app/api/domains/setup/route';
+
+const mockRequireAuth = requireAuth as jest.Mock;
+
+function makeReq(body: object) {
+  return new NextRequest('http://localhost/api/domains/setup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.HOSTED_ZONE_ID;
+});
+
+describe('POST /api/domains/setup', () => {
+  test('returns 401 for unauthenticated request', async () => {
+    mockRequireAuth.mockRejectedValue(new AuthError('Missing authentication token', 401));
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Missing authentication token');
+    expect(mockSesSend).not.toHaveBeenCalled();
+    expect(mockR53Send).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 for missing domain', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+
+    const res = await POST(makeReq({}));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid domain name');
+  });
+
+  test('returns 400 for invalid domain', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+
+    const res = await POST(makeReq({ domain: 'not_a_domain' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid domain name');
+  });
+
+  test('returns 409 when domain is already verified in SES', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockSesSend.mockResolvedValueOnce({
+      VerificationAttributes: { 'example.com': { VerificationStatus: 'Success' } },
+    });
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.error).toBe('Domain is already verified in SES');
+  });
+
+  test('happy path: creates DNS records and returns pending status', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+
+    // GetIdentityVerificationAttributes — domain not yet registered
+    mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
+    // VerifyDomainIdentityCommand
+    mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
+    // VerifyDomainDkimCommand
+    mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1', 'tok2', 'tok3'] });
+
+    // ListHostedZonesByNameCommand
+    mockR53Send.mockResolvedValueOnce({
+      HostedZones: [{ Id: '/hostedzone/Z123', Name: 'example.com.' }],
+    });
+    // ChangeResourceRecordSetsCommand
+    mockR53Send.mockResolvedValueOnce({
+      ChangeInfo: { Id: '/change/C456', Status: 'PENDING' },
+    });
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ domain: 'example.com', status: 'pending', changeId: '/change/C456' });
+
+    // Verify Route 53 received 5 changes: 1 TXT + 3 CNAME + 1 MX
+    const r53Call = mockR53Send.mock.calls[1][0];
+    expect(r53Call.ChangeBatch.Changes).toHaveLength(5);
+    const types = r53Call.ChangeBatch.Changes.map(
+      (c: { ResourceRecordSet: { Type: string } }) => c.ResourceRecordSet.Type,
+    );
+    expect(types.filter((t: string) => t === 'TXT')).toHaveLength(1);
+    expect(types.filter((t: string) => t === 'CNAME')).toHaveLength(3);
+    expect(types.filter((t: string) => t === 'MX')).toHaveLength(1);
+
+    // Verify TXT record has correct name and quoted token value
+    const txtRecord = r53Call.ChangeBatch.Changes.find(
+      (c: { ResourceRecordSet: { Type: string } }) => c.ResourceRecordSet.Type === 'TXT',
+    );
+    expect(txtRecord.ResourceRecordSet.Name).toBe('_amazonses.example.com');
+    expect(txtRecord.ResourceRecordSet.ResourceRecords[0].Value).toBe('"token-abc"');
+  });
+
+  test('uses HOSTED_ZONE_ID env var when set', async () => {
+    process.env.HOSTED_ZONE_ID = '/hostedzone/ZENV123';
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+
+    mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
+    mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
+    mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1', 'tok2', 'tok3'] });
+    mockR53Send.mockResolvedValueOnce({
+      ChangeInfo: { Id: '/change/CENV', Status: 'PENDING' },
+    });
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+
+    expect(res.status).toBe(200);
+    // Route 53 should NOT have called ListHostedZonesByNameCommand
+    expect(mockR53Send).toHaveBeenCalledTimes(1);
+    const r53Call = mockR53Send.mock.calls[0][0];
+    expect(r53Call.HostedZoneId).toBe('ZENV123');
+  });
+
+  test('returns 422 when no hosted zone found for domain', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+
+    mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
+    mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
+    mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1'] });
+    mockR53Send.mockResolvedValueOnce({ HostedZones: [] });
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.error).toMatch(/No Route 53 hosted zone/);
+  });
+});

--- a/app/app/api/domains/setup/route.ts
+++ b/app/app/api/domains/setup/route.ts
@@ -3,8 +3,18 @@ import {
   SESClient,
   VerifyDomainIdentityCommand,
   VerifyDomainDkimCommand,
+  GetIdentityVerificationAttributesCommand,
 } from '@aws-sdk/client-ses';
+import {
+  Route53Client,
+  ListHostedZonesByNameCommand,
+  ChangeResourceRecordSetsCommand,
+  ChangeAction,
+  RRType,
+} from '@aws-sdk/client-route-53';
 import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+
+const FQDN_RE = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
 
 export async function POST(req: NextRequest) {
   try {
@@ -17,22 +27,96 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json().catch(() => ({}));
-  const { domain } = body as { domain?: string };
+  const domain = ((body as { domain?: string })?.domain ?? '').trim().toLowerCase();
 
-  if (!domain || !/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(domain)) {
+  if (!domain || !FQDN_RE.test(domain)) {
     return NextResponse.json({ error: 'Invalid domain name' }, { status: 400 });
   }
 
-  const ses = new SESClient({ region: process.env.AWS_REGION ?? 'us-east-1' });
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+  const ses = new SESClient({ region });
+  const r53 = new Route53Client({ region });
 
-  const [verifyResult, dkimResult] = await Promise.all([
+  // Reject if domain is already active in SES
+  const attrsResult = await ses.send(
+    new GetIdentityVerificationAttributesCommand({ Identities: [domain] }),
+  );
+  if (attrsResult.VerificationAttributes?.[domain]?.VerificationStatus === 'Success') {
+    return NextResponse.json({ error: 'Domain is already verified in SES' }, { status: 409 });
+  }
+
+  // Register domain with SES and obtain verification token + DKIM tokens
+  const [identityResult, dkimResult] = await Promise.all([
     ses.send(new VerifyDomainIdentityCommand({ Domain: domain })),
     ses.send(new VerifyDomainDkimCommand({ Domain: domain })),
   ]);
+  const verificationToken = identityResult.VerificationToken;
+  const dkimTokens = dkimResult.DkimTokens ?? [];
+
+  // Resolve the Route 53 hosted zone
+  let zoneId: string;
+  const envZoneId = process.env.HOSTED_ZONE_ID;
+  if (envZoneId) {
+    zoneId = envZoneId.replace(/^\/hostedzone\//, '');
+  } else {
+    const zonesResult = await r53.send(
+      new ListHostedZonesByNameCommand({ DNSName: domain, MaxItems: 1 }),
+    );
+    const zone = zonesResult.HostedZones?.[0];
+    if (!zone) {
+      return NextResponse.json(
+        { error: `No Route 53 hosted zone found for ${domain}` },
+        { status: 422 },
+      );
+    }
+    zoneId = zone.Id.replace(/^\/hostedzone\//, '');
+  }
+
+  // Create domain verification TXT record, DKIM CNAME records, and MX record via Route 53
+  const changes = [
+    ...(verificationToken
+      ? [
+          {
+            Action: ChangeAction.CREATE,
+            ResourceRecordSet: {
+              Name: `_amazonses.${domain}`,
+              Type: RRType.TXT,
+              TTL: 1800,
+              ResourceRecords: [{ Value: `"${verificationToken}"` }],
+            },
+          },
+        ]
+      : []),
+    ...dkimTokens.map((token) => ({
+      Action: ChangeAction.CREATE,
+      ResourceRecordSet: {
+        Name: `${token}._domainkey.${domain}`,
+        Type: RRType.CNAME,
+        TTL: 1800,
+        ResourceRecords: [{ Value: `${token}.dkim.amazonses.com` }],
+      },
+    })),
+    {
+      Action: ChangeAction.CREATE,
+      ResourceRecordSet: {
+        Name: `${domain}.`,
+        Type: RRType.MX,
+        TTL: 300,
+        ResourceRecords: [{ Value: `10 inbound-smtp.${region}.amazonaws.com` }],
+      },
+    },
+  ];
+
+  const changeResult = await r53.send(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: zoneId,
+      ChangeBatch: { Changes: changes },
+    }),
+  );
 
   return NextResponse.json({
     domain,
-    verificationToken: verifyResult.VerificationToken,
-    dkimTokens: dkimResult.DkimTokens ?? [],
+    status: 'pending',
+    changeId: changeResult.ChangeInfo?.Id ?? null,
   });
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.758.0",
         "@aws-sdk/client-dynamodb": "^3.1034.0",
+        "@aws-sdk/client-route-53": "^3.1045.0",
         "@aws-sdk/client-s3": "^3.1037.0",
         "@aws-sdk/client-ses": "^3.1034.0",
         "@aws-sdk/lib-dynamodb": "^3.1034.0",
@@ -380,6 +381,58 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-route-53": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.1045.0.tgz",
+      "integrity": "sha512-u3xaIQKJPBd2S4wvUMGZhzgSLL1sJKHkS/urlWexaWyD4fHaZrs9Lfdp+8KUJ1J+PR9tzCjTaLmrmx6x5iL69g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-route53": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.1037.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1037.0.tgz",
@@ -498,13 +551,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
-      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.19",
+        "@aws-sdk/xml-builder": "^3.972.22",
         "@smithy/core": "^3.23.17",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
@@ -514,7 +567,7 @@
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -536,12 +589,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
-      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -552,12 +605,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
-      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.6.1",
@@ -573,19 +626,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
-      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/credential-provider-env": "^3.972.31",
-        "@aws-sdk/credential-provider-http": "^3.972.33",
-        "@aws-sdk/credential-provider-login": "^3.972.35",
-        "@aws-sdk/credential-provider-process": "^3.972.31",
-        "@aws-sdk/credential-provider-sso": "^3.972.35",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
-        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -598,13 +651,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
-      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -617,17 +670,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
-      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.31",
-        "@aws-sdk/credential-provider-http": "^3.972.33",
-        "@aws-sdk/credential-provider-ini": "^3.972.35",
-        "@aws-sdk/credential-provider-process": "^3.972.31",
-        "@aws-sdk/credential-provider-sso": "^3.972.35",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -640,12 +693,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
-      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -657,14 +710,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
-      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
-        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -676,13 +729,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
-      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -876,13 +929,27 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
-      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+    "node_modules/@aws-sdk/middleware-sdk-route53": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.972.12.tgz",
+      "integrity": "sha512-nj08j4q/Rp8zb3SqwxE+dex22NdXoSKJAh445x0SLGAI23lYfDTujFDG1JRYLRc1uR2/FPPr76L/ki/VE4J9ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.17",
@@ -916,18 +983,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
-      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@smithy/core": "^3.23.17",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-retry": "^4.3.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -935,24 +1002,24 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
-      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.17",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -960,7 +1027,7 @@
         "@smithy/invalid-dependency": "^4.2.14",
         "@smithy/middleware-content-length": "^4.2.14",
         "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-retry": "^4.5.7",
         "@smithy/middleware-serde": "^4.2.20",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
@@ -976,7 +1043,7 @@
         "@smithy/util-defaults-mode-node": "^4.2.54",
         "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1020,12 +1087,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
-      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -1037,13 +1104,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
-      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.5",
-        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1150,12 +1217,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
-      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -1175,13 +1242,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
-      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4532,20 +4600,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
+      "integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
+        "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4771,20 +4832,12 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
-      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.1.tgz",
+      "integrity": "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.4",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4897,18 +4950,6 @@
       "dependencies": {
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -5126,13 +5167,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
-      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
+      "integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.3.0",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5184,24 +5224,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.1.tgz",
+      "integrity": "sha512-G/gWDykZNL0NVcd1qXkoKm45jxJECp6q53DSomM5QKMsyAMEsGksVq+HwgonqYxfFJEzzHi6ljtWKXVS1pl0/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/core": "^3.24.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8728,9 +8756,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -8739,13 +8767,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -13377,9 +13406,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -14344,6 +14373,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.758.0",
     "@aws-sdk/client-dynamodb": "^3.1034.0",
+    "@aws-sdk/client-route-53": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.1037.0",
     "@aws-sdk/client-ses": "^3.1034.0",
     "@aws-sdk/lib-dynamodb": "^3.1034.0",


### PR DESCRIPTION
- POST /api/domains/setup: validates FQDN, checks for existing SES identity (409 if active), registers with SES, creates TXT + 3 DKIM CNAME + MX records in Route 53
- GET /api/domains/:domain/status: returns combined SES and DKIM verification status
- Install @aws-sdk/client-route-53
- Tests for both endpoints (happy path, 400/401/409/422 cases)

closes #92