### PR TITLE
[fix]: rename GET /api/messages response key from items to messages (…

### DIFF
--- a/app/__tests__/app/api/messages/route.test.ts
+++ b/app/__tests__/app/api/messages/route.test.ts
@@ -95,8 +95,8 @@ describe('GET /api/messages', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.items).toHaveLength(2);
-    expect(body.items[0].messageId).toBe('msg-2');
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].messageId).toBe('msg-2');
     expect(body.nextCursor).toBeNull();
   });
 

--- a/app/app/api/messages/route.ts
+++ b/app/app/api/messages/route.ts
@@ -105,7 +105,7 @@ export async function GET(req: NextRequest) {
     ? Buffer.from(JSON.stringify(result.LastEvaluatedKey)).toString('base64')
     : null;
 
-  return NextResponse.json({ items: result.Items ?? [], nextCursor });
+  return NextResponse.json({ messages: result.Items ?? [], nextCursor });
 }
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
…#120)

API returned { items } but the inbox page and MessageList both destructure/read { messages }, causing initialMessages to always be undefined and crashing with Cannot read properties of undefined (reading length).

closes #120