### PR TITLE
[feat]: add CI/CD GitHub Actions pipeline with ECR digest-pinned depl…

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,177 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPO: hermes-app
+  SSM_DIGEST_PARAM: /hermes/app-image-digest
+
+jobs:
+  # ── PR checks ────────────────────────────────────────────────────────────────
+  pr-checks:
+    if: github.event_name == 'pull_request'
+    name: PR — lint, test, cdk diff
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            app/package-lock.json
+            infra/package-lock.json
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install app dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: Run app tests
+        working-directory: app
+        run: npm test -- --no-coverage
+
+      - name: Install infra dependencies
+        working-directory: infra
+        run: npm ci
+
+      - name: Run infra tests
+        working-directory: infra
+        run: npm test
+
+      - name: CDK diff
+        id: cdk-diff
+        working-directory: infra
+        run: npx cdk diff --all 2>&1 | tee /tmp/cdk-diff.txt || true
+
+      - name: Post CDK diff as PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const diff = fs.readFileSync('/tmp/cdk-diff.txt', 'utf8');
+            const body = `## CDK Diff\n\`\`\`\n${diff.slice(0, 60000)}\n\`\`\``;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.startsWith('## CDK Diff'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+  # ── Deploy ───────────────────────────────────────────────────────────────────
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Deploy — build, push, cdk deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            app/package-lock.json
+            infra/package-lock.json
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install infra dependencies
+        working-directory: infra
+        run: npm ci
+
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app:
+              - 'app/**'
+            infra:
+              - 'infra/**'
+
+      - name: Log in to Amazon ECR
+        if: steps.changes.outputs.app == 'true'
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image to ECR
+        if: steps.changes.outputs.app == 'true'
+        id: docker-build
+        env:
+          REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+        run: |
+          IMAGE_URI="$REGISTRY/$ECR_REPO"
+          docker buildx build \
+            --platform linux/amd64 \
+            --push \
+            --tag "$IMAGE_URI:${{ github.sha }}" \
+            --tag "$IMAGE_URI:latest" \
+            app/
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE_URI:${{ github.sha }}" | cut -d@ -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
+
+      - name: Write image digest to SSM
+        if: steps.changes.outputs.app == 'true'
+        run: |
+          aws ssm put-parameter \
+            --name "$SSM_DIGEST_PARAM" \
+            --value "${{ steps.docker-build.outputs.digest }}" \
+            --type String \
+            --overwrite
+
+      - name: Read image digest from SSM (infra-only deploy)
+        if: steps.changes.outputs.app != 'true'
+        id: read-digest
+        run: |
+          DIGEST=$(aws ssm get-parameter --name "$SSM_DIGEST_PARAM" --query Parameter.Value --output text)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: CDK deploy
+        working-directory: infra
+        env:
+          IMAGE_DIGEST: ${{ steps.docker-build.outputs.digest || steps.read-digest.outputs.digest }}
+        run: |
+          npx cdk deploy --all \
+            --require-approval never \
+            --context imageDigest="$IMAGE_DIGEST"

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -6,6 +6,7 @@ import { HermesEmailStack } from '../lib/hermes-email-stack';
 import { HermesWebSocketStack } from '../lib/hermes-websocket-stack';
 import { HermesAppStack } from '../lib/hermes-app-stack';
 import { HermesCertStack } from '../lib/hermes-cert-stack';
+import { HermesEcrStack } from '../lib/hermes-ecr-stack';
 import { getConfig } from '../lib/config';
 
 const app = new cdk.App();
@@ -15,6 +16,8 @@ const env = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
   region: process.env.CDK_DEFAULT_REGION,
 };
+
+const ecrStack = new HermesEcrStack(app, 'HermesEcrStack', { env });
 
 const authStack = new HermesAuthStack(app, 'HermesAuthStack', { env });
 
@@ -51,6 +54,8 @@ const certStack = new HermesCertStack(app, 'HermesCertStack', {
   crossRegionReferences: true,
 });
 
+const imageDigest = app.node.tryGetContext('imageDigest') as string | undefined;
+
 new HermesAppStack(app, 'HermesAppStack', {
   env,
   crossRegionReferences: true,
@@ -67,4 +72,5 @@ new HermesAppStack(app, 'HermesAppStack', {
   domainName: config.domainName,
   certificate: certStack.certificate,
   hostedZoneDomainName: config.hostedZoneDomainName,
+  ...(imageDigest ? { appRepo: ecrStack.appRepo, imageDigest } : {}),
 });

--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as cdk from 'aws-cdk-lib/core';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
@@ -35,6 +36,10 @@ export interface HermesAppStackProps extends cdk.StackProps {
   certificate?: acm.ICertificate;
   /** Route 53 hosted zone domain (e.g. rpillai.dev) for creating the A record alias and DNS onboarding. */
   hostedZoneDomainName?: string;
+  /** ECR repository holding the pre-built app image. When provided with imageDigest, uses ECR instead of building locally. */
+  appRepo?: ecr.IRepository;
+  /** Image digest (sha256:...) written by CI. When set, pins the Lambda to this exact image. */
+  imageDigest?: string;
 }
 
 export class HermesAppStack extends cdk.Stack {
@@ -109,11 +114,15 @@ export class HermesAppStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
+    const appCode = props.appRepo && props.imageDigest
+      ? lambda.DockerImageCode.fromEcr(props.appRepo, { tagOrDigest: props.imageDigest })
+      : lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../../app'), {
+          platform: Platform.LINUX_AMD64,
+        });
+
     const appFunction = new lambda.DockerImageFunction(this, 'AppFunction', {
       functionName: 'hermes-app',
-      code: lambda.DockerImageCode.fromImageAsset(path.join(__dirname, '../../app'), {
-        platform: Platform.LINUX_AMD64,
-      }),
+      code: appCode,
       memorySize: 512,
       timeout: cdk.Duration.seconds(30),
       architecture: lambda.Architecture.X86_64,

--- a/infra/lib/hermes-ecr-stack.ts
+++ b/infra/lib/hermes-ecr-stack.ts
@@ -1,0 +1,31 @@
+import * as cdk from 'aws-cdk-lib/core';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { Construct } from 'constructs';
+
+const HERMES_TAG = { key: 'Project', value: 'hermes' };
+
+export class HermesEcrStack extends cdk.Stack {
+  public readonly appRepo: ecr.Repository;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.appRepo = new ecr.Repository(this, 'AppRepo', {
+      repositoryName: 'hermes-app',
+      imageScanOnPush: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      lifecycleRules: [
+        {
+          maxImageCount: 10,
+          description: 'Keep last 10 images',
+        },
+      ],
+    });
+    cdk.Tags.of(this.appRepo).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    new cdk.CfnOutput(this, 'AppRepoUri', {
+      exportName: 'HermesAppRepoUri',
+      value: this.appRepo.repositoryUri,
+    });
+  }
+}


### PR DESCRIPTION
…oys (#45)

- Add HermesEcrStack with ECR repository (hermes-app) for pre-built images
- Update HermesAppStack to accept appRepo + imageDigest; uses fromEcr when both are set, falls back to fromImageAsset for local dev
- Update infra/bin/infra.ts: instantiate HermesEcrStack, pass imageDigest CDK context to HermesAppStack
- Add .github/workflows/app.yml with PR checks (lint, test, cdk diff as comment) and deploy job (OIDC, Docker build/push to ECR, digest written to SSM, cdk deploy --all with digest pinned via -c imageDigest)
- Infra-only changes skip Docker build and read existing digest from SSM

closes #45