### PR TITLE
[feat]: complete Sprint 5 WebSocket, settings, and health-check tests…

### DIFF
--- a/app/__tests__/app/api/domains/setup/route.test.ts
+++ b/app/__tests__/app/api/domains/setup/route.test.ts
@@ -60,9 +60,14 @@ function makeReq(body: object) {
   });
 }
 
+function mockZoneFound(domain = 'example.com', zoneId = '/hostedzone/Z123') {
+  mockR53Send.mockResolvedValueOnce({
+    HostedZones: [{ Id: zoneId, Name: `${domain}.` }],
+  });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
-  delete process.env.HOSTED_ZONE_ID;
 });
 
 describe('POST /api/domains/setup', () => {
@@ -98,8 +103,21 @@ describe('POST /api/domains/setup', () => {
     expect(body.error).toBe('Invalid domain name');
   });
 
+  test('returns 422 when no hosted zone found for domain', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockR53Send.mockResolvedValueOnce({ HostedZones: [] });
+
+    const res = await POST(makeReq({ domain: 'example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.error).toMatch(/not hosted in Route 53/);
+    expect(mockSesSend).not.toHaveBeenCalled();
+  });
+
   test('returns 409 when domain is already verified in SES', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockZoneFound();
     mockSesSend.mockResolvedValueOnce({
       VerificationAttributes: { 'example.com': { VerificationStatus: 'Success' } },
     });
@@ -114,17 +132,13 @@ describe('POST /api/domains/setup', () => {
   test('happy path: creates DNS records and returns pending status', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
 
-    // GetIdentityVerificationAttributes — domain not yet registered
+    // Route 53 — zone found
+    mockZoneFound();
+    // SES — domain not yet registered
     mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
-    // VerifyDomainIdentityCommand
+    // VerifyDomainIdentityCommand + VerifyDomainDkimCommand (called in parallel)
     mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
-    // VerifyDomainDkimCommand
     mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1', 'tok2', 'tok3'] });
-
-    // ListHostedZonesByNameCommand
-    mockR53Send.mockResolvedValueOnce({
-      HostedZones: [{ Id: '/hostedzone/Z123', Name: 'example.com.' }],
-    });
     // ChangeResourceRecordSetsCommand
     mockR53Send.mockResolvedValueOnce({
       ChangeInfo: { Id: '/change/C456', Status: 'PENDING' },
@@ -152,40 +166,5 @@ describe('POST /api/domains/setup', () => {
     );
     expect(txtRecord.ResourceRecordSet.Name).toBe('_amazonses.example.com');
     expect(txtRecord.ResourceRecordSet.ResourceRecords[0].Value).toBe('"token-abc"');
-  });
-
-  test('uses HOSTED_ZONE_ID env var when set', async () => {
-    process.env.HOSTED_ZONE_ID = '/hostedzone/ZENV123';
-    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
-
-    mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
-    mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
-    mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1', 'tok2', 'tok3'] });
-    mockR53Send.mockResolvedValueOnce({
-      ChangeInfo: { Id: '/change/CENV', Status: 'PENDING' },
-    });
-
-    const res = await POST(makeReq({ domain: 'example.com' }));
-
-    expect(res.status).toBe(200);
-    // Route 53 should NOT have called ListHostedZonesByNameCommand
-    expect(mockR53Send).toHaveBeenCalledTimes(1);
-    const r53Call = mockR53Send.mock.calls[0][0];
-    expect(r53Call.HostedZoneId).toBe('ZENV123');
-  });
-
-  test('returns 422 when no hosted zone found for domain', async () => {
-    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
-
-    mockSesSend.mockResolvedValueOnce({ VerificationAttributes: {} });
-    mockSesSend.mockResolvedValueOnce({ VerificationToken: 'token-abc' });
-    mockSesSend.mockResolvedValueOnce({ DkimTokens: ['tok1'] });
-    mockR53Send.mockResolvedValueOnce({ HostedZones: [] });
-
-    const res = await POST(makeReq({ domain: 'example.com' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(422);
-    expect(body.error).toMatch(/No Route 53 hosted zone/);
   });
 });

--- a/app/__tests__/app/api/health/route.test.ts
+++ b/app/__tests__/app/api/health/route.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/health/route';
+
+describe('GET /api/health', () => {
+  test('returns 200 with ok status', async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -15,19 +15,30 @@ jest.mock('next/navigation', () => ({
 let wsHandler: ((event: WsNewMessageEvent) => void) | null = null;
 const mockSubscribe = jest.fn((handler: (event: WsNewMessageEvent) => void) => {
   wsHandler = handler;
-  return () => { wsHandler = null; };
+  return () => {
+    wsHandler = null;
+  };
 });
 
 jest.mock('@/components/ws-context', () => ({
   useWs: () => ({ subscribe: mockSubscribe }),
+}));
+
 jest.mock('@/components/compose-context', () => ({
-  useCompose: () => ({ openCompose: mockOpenCompose, closeCompose: jest.fn(), isOpen: false, initialData: null }),
+  useCompose: () => ({
+    openCompose: mockOpenCompose,
+    closeCompose: jest.fn(),
+    isOpen: false,
+    initialData: null,
+  }),
 }));
 
 jest.mock('@/components/ui/tooltip', () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
   TooltipContent: () => null,
 }));
 
@@ -66,9 +77,10 @@ describe('Sidebar', () => {
     expect(screen.getByText(/no addresses yet/i)).toBeInTheDocument();
   });
 
-  test('renders Compose, Drafts, Settings links', () => {
+  test('renders Compose, Domains, Drafts, Settings links', () => {
     render(<Sidebar addresses={ADDRESSES} />);
     expect(screen.getByText('Compose')).toBeInTheDocument();
+    expect(screen.getByText('Domains')).toBeInTheDocument();
     expect(screen.getByText('Drafts')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });
@@ -94,6 +106,8 @@ describe('Sidebar', () => {
     await waitFor(() => {
       expect(screen.getByText('1')).toBeInTheDocument();
     });
+  });
+
   test('Compose button opens compose sheet via context', async () => {
     const user = userEvent.setup();
     render(<Sidebar addresses={ADDRESSES} />);

--- a/app/app/api/health/route.ts
+++ b/app/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/app/app/login/login-form.tsx
+++ b/app/app/login/login-form.tsx
@@ -16,7 +16,7 @@ export function LoginForm() {
 
   useEffect(() => {
     if (state.success) {
-      router.push('/addresses');
+      router.push('/');
     }
   }, [state.success, router]);
 


### PR DESCRIPTION
… (#47)

- Fix sidebar.test.tsx syntax bugs and restore all WebSocket badge increment tests
- Fix login-form.tsx redirect from /addresses to / (dashboard) and update test
- Update POST /api/domains/setup tests to match refactored route (zone-first flow, updated error message)
- Add GET /api/health endpoint and unit test for Docker health-check requirement

closes #47