### PR TITLE
[test]: add domain onboarding frontend tests (#94)

### DIFF
--- a/app/__tests__/components/domains/add-domain-dialog.test.tsx
+++ b/app/__tests__/components/domains/add-domain-dialog.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AddDomainDialog } from '@/components/domains/add-domain-dialog';
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+function renderDialog(onSuccess = jest.fn()) {
+  return render(<AddDomainDialog onSuccess={onSuccess} />);
+}
+
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /add domain/i }));
+}
+
+describe('AddDomainDialog', () => {
+  describe('form submission', () => {
+    test('opens dialog when trigger button is clicked', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderDialog();
+      await openDialog(user);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    test('shows pending status panel after successful setup submission', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ ses: 'Pending', dkim: 'Pending' }),
+        });
+
+      renderDialog();
+      await openDialog(user);
+
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'mysite.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/verifying/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/SES verification/i)).toBeInTheDocument();
+      expect(screen.getByText(/DKIM/i)).toBeInTheDocument();
+    });
+
+    test('shows error alert when setup request fails', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: 'Domain is already verified in SES' }),
+      });
+
+      renderDialog();
+      await openDialog(user);
+
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'taken.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/domain is already verified in ses/i)).toBeInTheDocument();
+      });
+    });
+
+    test('shows error when form is submitted with empty domain', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderDialog();
+      await openDialog(user);
+
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      expect(screen.getByText(/domain name is required/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('status panel polling', () => {
+    test('status panel shows Pending badges initially after submission', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ ses: 'Pending', dkim: 'Pending' }),
+        });
+
+      renderDialog();
+      await openDialog(user);
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'mysite.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Pending')).toHaveLength(2);
+      });
+    });
+
+    test('calls onSuccess and shows success alert when both statuses become Verified', async () => {
+      const onSuccess = jest.fn();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ ses: 'Verified', dkim: 'Verified' }),
+        });
+
+      renderDialog(onSuccess);
+      await openDialog(user);
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'mysite.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.getByText(/domain verified successfully/i)).toBeInTheDocument();
+    });
+
+    test('shows Failed badge when SES status is Failed', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ ses: 'Failed', dkim: 'Pending' }),
+        });
+
+      renderDialog();
+      await openDialog(user);
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'mysite.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed')).toBeInTheDocument();
+      });
+    });
+
+    test('polls for status updates every 5 seconds', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ ses: 'Pending', dkim: 'Pending' }),
+        });
+
+      renderDialog();
+      await openDialog(user);
+      await user.type(screen.getByPlaceholderText(/example\.com/i), 'mysite.com');
+      await user.click(screen.getByRole('button', { name: /set up domain/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/verifying/i)).toBeInTheDocument();
+      });
+
+      const callsBefore = (global.fetch as jest.Mock).mock.calls.length;
+      act(() => {
+        jest.advanceTimersByTime(5_000);
+      });
+      await waitFor(() => {
+        expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(callsBefore);
+      });
+    });
+  });
+});

--- a/app/__tests__/components/domains/domain-list.test.tsx
+++ b/app/__tests__/components/domains/domain-list.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { DomainList } from '@/components/domains/domain-list';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn().mockReturnValue({ refresh: jest.fn() }),
+}));
+
+jest.mock('@/components/domains/add-domain-dialog', () => ({
+  AddDomainDialog: ({ onSuccess }: { onSuccess: () => void }) => (
+    <button onClick={onSuccess}>Add domain</button>
+  ),
+}));
+
+const DOMAINS = [
+  { domain: 'example.com', status: 'Verified' as const },
+  { domain: 'pending.com', status: 'Pending' as const },
+  { domain: 'failed.com', status: 'Failed' as const },
+];
+
+describe('DomainList', () => {
+  test('renders all domain rows', () => {
+    render(<DomainList domains={DOMAINS} />);
+    expect(screen.getByText('example.com')).toBeInTheDocument();
+    expect(screen.getByText('pending.com')).toBeInTheDocument();
+    expect(screen.getByText('failed.com')).toBeInTheDocument();
+  });
+
+  test('shows Verified badge for verified domain', () => {
+    render(<DomainList domains={DOMAINS} />);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+
+  test('shows Pending badge for pending domain', () => {
+    render(<DomainList domains={DOMAINS} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  test('shows Failed badge for failed domain', () => {
+    render(<DomainList domains={DOMAINS} />);
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  test('shows empty state when no domains', () => {
+    render(<DomainList domains={[]} />);
+    expect(screen.getByText(/no domains yet/i)).toBeInTheDocument();
+  });
+
+  test('renders Add domain button', () => {
+    render(<DomainList domains={[]} />);
+    expect(screen.getByRole('button', { name: /add domain/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- domain-list.test.tsx: renders all domains, Verified/Pending/Failed status badges, empty state
- add-domain-dialog.test.tsx: form submit -> pending status panel, error states, polling, Verified success alert, Failed badge

closes #94