### PR TITLE
[fix]: restructure CI workflow so tests run without AWS credentials

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -17,10 +17,9 @@ env:
   SSM_DIGEST_PARAM: /hermes/app-image-digest
 
 jobs:
-  # ── PR checks ────────────────────────────────────────────────────────────────
-  pr-checks:
-    if: github.event_name == 'pull_request'
-    name: PR — lint, test, cdk diff
+  # ── Tests (no AWS required) ──────────────────────────────────────────────────
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     steps:
@@ -34,12 +33,6 @@ jobs:
           cache-dependency-path: |
             app/package-lock.json
             infra/package-lock.json
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Install app dependencies
         working-directory: app
@@ -57,7 +50,37 @@ jobs:
         working-directory: infra
         run: npm test
 
+  # ── CDK diff on PRs (requires AWS OIDC) ─────────────────────────────────────
+  cdk-diff:
+    if: github.event_name == 'pull_request'
+    name: CDK diff
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: infra/package-lock.json
+
+      - name: Configure AWS credentials (OIDC)
+        id: aws-creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install infra dependencies
+        working-directory: infra
+        run: npm ci
+
       - name: CDK diff
+        if: steps.aws-creds.outcome == 'success'
         id: cdk-diff
         working-directory: infra
         run: npx cdk diff --all 2>&1 | tee /tmp/cdk-diff.txt || true
@@ -91,11 +114,12 @@ jobs:
               });
             }
 
-  # ── Deploy ───────────────────────────────────────────────────────────────────
+  # ── Deploy on push to main (requires AWS OIDC) ───────────────────────────────
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    name: Deploy — build, push, cdk deploy
+    name: Deploy
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
       - uses: actions/checkout@v4
@@ -105,14 +129,12 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: |
-            app/package-lock.json
-            infra/package-lock.json
+          cache-dependency-path: infra/package-lock.json
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install infra dependencies


### PR DESCRIPTION
- Split monolithic job into three: test (always runs), cdk-diff (PR only), deploy (main only)
- Test job has no AWS dependency - unit tests pass regardless of OIDC setup
- cdk-diff and deploy jobs run after test passes (needs: test)
- cdk-diff uses continue-on-error on credential step + gates CDK diff on success, so missing OIDC doesn't fail the job
- Switch AWS_ROLE_ARN from vars to secrets context
- cdk-diff and deploy jobs share no steps with test, keeping each job minimal