### PR TITLE
[fix]: use secrets context for AWS_ROLE_ARN

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install infra dependencies
@@ -135,7 +135,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install infra dependencies


### PR DESCRIPTION
vars context resolves to empty when variable is stored as a secret. Switching to secrets.AWS_ROLE_ARN to match where it was configured.