### PR TITLE
[fix]: correct deploy region to us-west-2 where infrastructure lives

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 env:
-  AWS_REGION: us-east-1
+  AWS_REGION: us-west-2
   ECR_REPO: hermes-app
   SSM_DIGEST_PARAM: /hermes/app-image-digest
 

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -22,6 +22,7 @@ const ecrStack = new HermesEcrStack(app, 'HermesEcrStack', { env });
 
 new HermesGithubRoleStack(app, 'HermesGithubRoleStack', {
   env: { account: env.account, region: 'us-east-1' },
+  deployRegion: env.region ?? 'us-west-2',
   ecrRepositoryName: ecrStack.appRepo.repositoryName,
   ssmDigestParam: '/hermes/app-image-digest',
 });

--- a/infra/lib/hermes-github-role-stack.ts
+++ b/infra/lib/hermes-github-role-stack.ts
@@ -13,6 +13,12 @@ export interface HermesGithubRoleStackProps extends cdk.StackProps {
   ecrRepositoryName: string;
   /** SSM parameter name for the image digest. */
   ssmDigestParam: string;
+  /**
+   * Region where the app stacks (Storage, App, Email, etc.) are deployed.
+   * Used for CDK bootstrap role ARNs, ECR, and SSM resource ARNs.
+   * Separate from the stack's own region since IAM is global.
+   */
+  deployRegion: string;
 }
 
 export class HermesGithubRoleStack extends cdk.Stack {
@@ -44,10 +50,10 @@ export class HermesGithubRoleStack extends cdk.Stack {
       sid: 'CdkBootstrapRoles',
       actions: ['sts:AssumeRole'],
       resources: [
-        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-deploy-role-${this.account}-${this.region}`,
-        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-file-publishing-role-${this.account}-${this.region}`,
-        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-image-publishing-role-${this.account}-${this.region}`,
-        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-lookup-role-${this.account}-${this.region}`,
+        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-deploy-role-${this.account}-${props.deployRegion}`,
+        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-file-publishing-role-${this.account}-${props.deployRegion}`,
+        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-image-publishing-role-${this.account}-${props.deployRegion}`,
+        `arn:aws:iam::${this.account}:role/cdk-${CDK_QUALIFIER}-lookup-role-${this.account}-${props.deployRegion}`,
       ],
     }));
 
@@ -70,7 +76,7 @@ export class HermesGithubRoleStack extends cdk.Stack {
         'ecr:GetDownloadUrlForLayer',
       ],
       resources: [
-        `arn:aws:ecr:${this.region}:${this.account}:repository/${props.ecrRepositoryName}`,
+        `arn:aws:ecr:${props.deployRegion}:${this.account}:repository/${props.ecrRepositoryName}`,
       ],
     }));
 
@@ -79,7 +85,7 @@ export class HermesGithubRoleStack extends cdk.Stack {
       sid: 'SsmDigest',
       actions: ['ssm:PutParameter', 'ssm:GetParameter'],
       resources: [
-        `arn:aws:ssm:${this.region}:${this.account}:parameter${props.ssmDigestParam}`,
+        `arn:aws:ssm:${props.deployRegion}:${this.account}:parameter${props.ssmDigestParam}`,
       ],
     }));
 


### PR DESCRIPTION
Workflow was set to us-east-1 causing CDK to try creating new stacks that conflicted with existing us-west-2 resources. Changes:
- Set AWS_REGION to us-west-2 in workflow
- Add deployRegion prop to HermesGithubRoleStack so CDK bootstrap role ARNs, ECR and SSM resource ARNs use the correct region independent of where the IAM stack itself is deployed