### PR TITLE
[fix]: show outbound messages in inbox with Sent badge and recipient …

### DIFF
--- a/app/__tests__/components/inbox/message-list.test.tsx
+++ b/app/__tests__/components/inbox/message-list.test.tsx
@@ -30,6 +30,7 @@ const MESSAGES = [
     messageId: 'msg-1',
     address: 'hello@example.com',
     sender: 'alice@test.com',
+    direction: 'inbound' as const,
     subject: 'Hello',
     receivedAt: '2026-01-01T10:00:00Z',
     isRead: true,
@@ -39,12 +40,25 @@ const MESSAGES = [
     messageId: 'msg-2',
     address: 'hello@example.com',
     sender: 'bob@test.com',
+    direction: 'inbound' as const,
     subject: 'World',
     receivedAt: '2026-01-02T10:00:00Z',
     isRead: false,
     attachments: [{ filename: 'file.pdf', s3Key: 'key' }],
   },
 ];
+
+const OUTBOUND_MESSAGE = {
+  messageId: 'msg-out',
+  address: 'hello@example.com',
+  from: 'hello@example.com',
+  to: 'recipient@test.com',
+  direction: 'outbound' as const,
+  subject: 'Re: Hello',
+  receivedAt: '2026-01-03T10:00:00Z',
+  isRead: true,
+  attachments: [],
+};
 
 beforeEach(() => {
   global.fetch = jest.fn();
@@ -174,6 +188,19 @@ describe('MessageList', () => {
     });
 
     expect(screen.getAllByText('alice@test.com')).toHaveLength(1);
+  });
+
+  test('shows Sent badge and recipient for outbound messages', () => {
+    render(<MessageList address="hello@example.com" initialMessages={[OUTBOUND_MESSAGE]} initialNextCursor={null} />);
+    expect(screen.getByText('Sent')).toBeInTheDocument();
+    expect(screen.getByText('recipient@test.com')).toBeInTheDocument();
+    expect(screen.getByText('Re: Hello')).toBeInTheDocument();
+  });
+
+  test('does not show unread badge for outbound messages', () => {
+    const unreadOutbound = { ...OUTBOUND_MESSAGE, isRead: false };
+    render(<MessageList address="hello@example.com" initialMessages={[unreadOutbound]} initialNextCursor={null} />);
+    expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
   });
 
   test('navigates to message detail on row click', async () => {

--- a/app/app/(app)/inbox/[address]/page.tsx
+++ b/app/app/(app)/inbox/[address]/page.tsx
@@ -5,7 +5,10 @@ import { MessageList } from '@/components/inbox/message-list';
 interface Message {
   messageId: string;
   address: string;
-  sender: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  direction?: 'inbound' | 'outbound';
   subject: string;
   receivedAt: string;
   isRead: boolean;

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -26,7 +26,10 @@ interface Attachment {
 interface Message {
   messageId: string;
   address: string;
-  sender: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  direction?: 'inbound' | 'outbound';
   subject: string;
   receivedAt: string;
   isRead: boolean;
@@ -105,7 +108,7 @@ export function MessageList({ address, initialMessages, initialNextCursor }: Mes
         <TableHeader>
           <TableRow>
             <TableHead className="w-8"></TableHead>
-            <TableHead>From</TableHead>
+            <TableHead>From / To</TableHead>
             <TableHead>Subject</TableHead>
             <TableHead className="text-right">Date</TableHead>
           </TableRow>
@@ -127,12 +130,14 @@ export function MessageList({ address, initialMessages, initialNextCursor }: Mes
               </TableCell>
             </TableRow>
           ) : (
-            messages.map((msg) => (
+            messages.map((msg) => {
+              const isOutbound = msg.direction === 'outbound';
+              return (
               <TableRow
                 key={msg.messageId}
                 className={cn(
                   'cursor-pointer hover:bg-accent',
-                  !msg.isRead && 'bg-accent/30 font-medium',
+                  !msg.isRead && !isOutbound && 'bg-accent/30 font-medium',
                 )}
                 onClick={() => handleRowClick(msg)}
               >
@@ -143,10 +148,17 @@ export function MessageList({ address, initialMessages, initialNextCursor }: Mes
                 </TableCell>
                 <TableCell className="py-2">
                   <div className="flex items-center gap-2">
-                    {!msg.isRead && (
+                    {!msg.isRead && !isOutbound && (
                       <Badge variant="default" className="h-4 w-4 shrink-0 rounded-full p-0" aria-label="Unread" />
                     )}
-                    <span className="truncate max-w-45">{msg.sender}</span>
+                    {isOutbound ? (
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <Badge variant="secondary" className="text-xs shrink-0">Sent</Badge>
+                        <span className="truncate max-w-45 text-muted-foreground">{msg.to}</span>
+                      </div>
+                    ) : (
+                      <span className="truncate max-w-45">{msg.sender}</span>
+                    )}
                   </div>
                 </TableCell>
                 <TableCell className="py-2 truncate max-w-xs">{msg.subject}</TableCell>
@@ -154,7 +166,8 @@ export function MessageList({ address, initialMessages, initialNextCursor }: Mes
                   {new Date(msg.receivedAt).toLocaleDateString()}
                 </TableCell>
               </TableRow>
-            ))
+              );
+            })
           )}
         </TableBody>
       </Table>


### PR DESCRIPTION
…(#134)

Replies and composed messages were stored with from/to fields but the MessageList component only read the sender field, leaving the From column blank and making sent messages invisible to the user.

Extend the Message interface with direction, from, and to fields. For outbound rows render a Sent badge and the recipient address in the From/To column instead of sender, and skip the unread dot and bold styling.

closes #134