### PR TITLE
[fix]: make sender optional in MessageDetail and WsNewMessageEvent (#…

### DIFF
--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -18,7 +18,7 @@ interface Attachment {
 
 interface Message {
   messageId: string;
-  sender: string;
+  sender?: string;
   subject: string;
   receivedAt: string;
   isRead: boolean;

--- a/app/lib/ws.ts
+++ b/app/lib/ws.ts
@@ -4,7 +4,7 @@ export interface WsNewMessageEvent {
   message: {
     messageId: string;
     address: string;
-    sender: string;
+    sender?: string;
     subject: string;
     receivedAt: string;
     isRead: boolean;


### PR DESCRIPTION
…137)

sender is not guaranteed on all message types; display falls back to from field

closes #137