### PR TITLE
[fix]: show success feedback and update list immediately after adding…

### DIFF
--- a/app/components/addresses/add-address-dialog.tsx
+++ b/app/components/addresses/add-address-dialog.tsx
@@ -21,9 +21,16 @@ import {
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
+interface NewAddress {
+  email: string;
+  domain: string;
+  status: string;
+  createdAt: string;
+}
+
 interface AddAddressDialogProps {
   domains: string[];
-  onSuccess: () => void;
+  onSuccess: (address: NewAddress) => void;
 }
 
 export function AddAddressDialog({ domains, onSuccess }: AddAddressDialogProps) {
@@ -49,10 +56,11 @@ export function AddAddressDialog({ domains, onSuccess }: AddAddressDialogProps) 
         body: JSON.stringify({ email }),
       });
       if (res.ok) {
+        const data = await res.json();
         setLocalPart('');
         setDomain('');
         setOpen(false);
-        onSuccess();
+        onSuccess(data.address);
       } else {
         const data = await res.json().catch(() => ({}));
         setError(data.error ?? 'Failed to add address');

--- a/app/components/addresses/address-list.tsx
+++ b/app/components/addresses/address-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Table,
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AddAddressDialog } from './add-address-dialog';
 import { DeleteAddressDialog } from './delete-address-dialog';
 
@@ -35,15 +36,28 @@ function statusVariant(status: string): 'default' | 'secondary' | 'destructive' 
 export function AddressList({ addresses: initial, domains }: AddressListProps) {
   const router = useRouter();
   const [addresses, setAddresses] = useState<Address[]>(initial);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  function refresh() {
+  useEffect(() => {
+    setAddresses(initial);
+  }, [initial]);
+
+  function handleAddSuccess(address: Address) {
+    setAddresses((prev) => [address, ...prev]);
+    setSuccessMessage(`${address.email} added successfully`);
+    setTimeout(() => setSuccessMessage(null), 4000);
     router.refresh();
   }
 
   return (
     <div className="space-y-4">
+      {successMessage && (
+        <Alert>
+          <AlertDescription>{successMessage}</AlertDescription>
+        </Alert>
+      )}
       <div className="flex justify-end">
-        <AddAddressDialog domains={domains} onSuccess={refresh} />
+        <AddAddressDialog domains={domains} onSuccess={handleAddSuccess} />
       </div>
       <Table>
         <TableHeader>


### PR DESCRIPTION
… address

Optimistically prepend new address to list from API response and show a 4-second success alert; add useEffect to sync state when router.refresh re-fetches server props so the list stays consistent.