### PR TITLE
[fix]: fix search filters not working in inbox and sent mailboxes (#150)

### DIFF
--- a/app/__tests__/app/api/messages/route.test.ts
+++ b/app/__tests__/app/api/messages/route.test.ts
@@ -144,7 +144,7 @@ describe('GET /api/messages', () => {
     expect(queryArg).toMatchObject({ ExclusiveStartKey: lastKey });
   });
 
-  test('filters by sender using contains (case-insensitive)', async () => {
+  test('filters by sender searching the from attribute (lowercased value)', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
@@ -152,12 +152,13 @@ describe('GET /api/messages', () => {
 
     const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
     expect(queryArg).toMatchObject({
-      FilterExpression: expect.stringContaining('contains(#sender, :sender)'),
+      FilterExpression: expect.stringContaining('contains(#from, :sender)'),
+      ExpressionAttributeNames: expect.objectContaining({ '#from': 'from' }),
       ExpressionAttributeValues: expect.objectContaining({ ':sender': 'alice' }),
     });
   });
 
-  test('filters by subject using contains (case-insensitive)', async () => {
+  test('filters by subject using contains preserving original case', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
@@ -166,48 +167,67 @@ describe('GET /api/messages', () => {
     const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
     expect(queryArg).toMatchObject({
       FilterExpression: expect.stringContaining('contains(#subject, :subject)'),
-      ExpressionAttributeValues: expect.objectContaining({ ':subject': 'hello world' }),
+      ExpressionAttributeValues: expect.objectContaining({ ':subject': 'Hello World' }),
     });
   });
 
-  test('filters by from date using >= comparison', async () => {
+  test('date after filter uses KeyConditionExpression range on GSI sort key', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
-    await GET(makeGetReq({ address: 'inbox@example.com', from: '2024-01-01T00:00:00Z' }));
+    await GET(makeGetReq({ address: 'inbox@example.com', from: '2024-01-01' }));
 
     const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
     expect(queryArg).toMatchObject({
-      FilterExpression: expect.stringContaining('#receivedAt >= :from'),
-      ExpressionAttributeValues: expect.objectContaining({ ':from': '2024-01-01T00:00:00Z' }),
+      KeyConditionExpression: expect.stringContaining('#receivedAt >= :from'),
+      ExpressionAttributeValues: expect.objectContaining({ ':from': '2024-01-01' }),
     });
+    expect(queryArg.FilterExpression ?? '').not.toContain('#receivedAt');
   });
 
-  test('filters by to date using <= comparison', async () => {
+  test('date before filter uses KeyConditionExpression range and appends end-of-day', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
-    await GET(makeGetReq({ address: 'inbox@example.com', to: '2024-01-31T23:59:59Z' }));
+    await GET(makeGetReq({ address: 'inbox@example.com', to: '2024-01-31' }));
 
     const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
     expect(queryArg).toMatchObject({
-      FilterExpression: expect.stringContaining('#receivedAt <= :to'),
-      ExpressionAttributeValues: expect.objectContaining({ ':to': '2024-01-31T23:59:59Z' }),
+      KeyConditionExpression: expect.stringContaining('#receivedAt <= :to'),
+      ExpressionAttributeValues: expect.objectContaining({ ':to': '2024-01-31T23:59:59.999Z' }),
     });
+    expect(queryArg.FilterExpression ?? '').not.toContain('#receivedAt');
   });
 
-  test('combines multiple filters with AND', async () => {
+  test('both date filters use BETWEEN in KeyConditionExpression', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
 
-    await GET(makeGetReq({ address: 'inbox@example.com', sender: 'alice', from: '2024-01-01T00:00:00Z', to: '2024-01-31T23:59:59Z' }));
+    await GET(makeGetReq({ address: 'inbox@example.com', from: '2024-01-01', to: '2024-01-31' }));
 
     const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(queryArg).toMatchObject({
+      KeyConditionExpression: expect.stringContaining('BETWEEN :from AND :to'),
+      ExpressionAttributeValues: expect.objectContaining({
+        ':from': '2024-01-01',
+        ':to': '2024-01-31T23:59:59.999Z',
+      }),
+    });
+  });
+
+  test('combines sender and subject filters with AND in FilterExpression', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+
+    await GET(makeGetReq({ address: 'inbox@example.com', sender: 'alice', subject: 'Hello', from: '2024-01-01' }));
+
+    const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(queryArg.KeyConditionExpression).toContain('#receivedAt >= :from');
     const filter = queryArg.FilterExpression as string;
-    expect(filter).toContain('contains(#sender, :sender)');
-    expect(filter).toContain('#receivedAt >= :from');
-    expect(filter).toContain('#receivedAt <= :to');
+    expect(filter).toContain('contains(#from, :sender)');
+    expect(filter).toContain('contains(#subject, :subject)');
     expect(filter).toMatch(/AND/);
+    expect(filter).not.toContain('#receivedAt');
   });
 
   test('does not include FilterExpression when no filters provided', async () => {

--- a/app/app/api/messages/route.ts
+++ b/app/app/api/messages/route.ts
@@ -60,6 +60,26 @@ export async function GET(req: NextRequest) {
     ':address': address,
   };
 
+  // receivedAt is the GSI sort key — it must go in KeyConditionExpression, not
+  // FilterExpression (DynamoDB rejects key attributes in FilterExpression).
+  // Only declare #receivedAt when it is actually referenced to avoid the
+  // "unused expression attribute name" ValidationException.
+  let keyConditionExpression = '#address = :address';
+  if (from && to) {
+    keyConditionExpression += ' AND #receivedAt BETWEEN :from AND :to';
+    expressionAttributeNames['#receivedAt'] = 'receivedAt';
+    expressionAttributeValues[':from'] = from;
+    expressionAttributeValues[':to'] = `${to}T23:59:59.999Z`;
+  } else if (from) {
+    keyConditionExpression += ' AND #receivedAt >= :from';
+    expressionAttributeNames['#receivedAt'] = 'receivedAt';
+    expressionAttributeValues[':from'] = from;
+  } else if (to) {
+    keyConditionExpression += ' AND #receivedAt <= :to';
+    expressionAttributeNames['#receivedAt'] = 'receivedAt';
+    expressionAttributeValues[':to'] = `${to}T23:59:59.999Z`;
+  }
+
   if (direction) {
     filterConditions.push('#direction = :direction');
     expressionAttributeNames['#direction'] = 'direction';
@@ -67,36 +87,22 @@ export async function GET(req: NextRequest) {
   }
 
   if (sender) {
-    filterConditions.push('contains(#sender, :sender)');
-    expressionAttributeNames['#sender'] = 'sender';
+    filterConditions.push('contains(#from, :sender)');
+    expressionAttributeNames['#from'] = 'from';
     expressionAttributeValues[':sender'] = sender.toLowerCase();
   }
 
   if (subject) {
     filterConditions.push('contains(#subject, :subject)');
     expressionAttributeNames['#subject'] = 'subject';
-    expressionAttributeValues[':subject'] = subject.toLowerCase();
-  }
-
-  if (from) {
-    filterConditions.push('#receivedAt >= :from');
-    expressionAttributeNames['#receivedAt'] = 'receivedAt';
-    expressionAttributeValues[':from'] = from;
-  }
-
-  if (to) {
-    if (!expressionAttributeNames['#receivedAt']) {
-      expressionAttributeNames['#receivedAt'] = 'receivedAt';
-    }
-    filterConditions.push('#receivedAt <= :to');
-    expressionAttributeValues[':to'] = to;
+    expressionAttributeValues[':subject'] = subject;
   }
 
   const dynamo = getDynamo();
   const result = await dynamo.send(new QueryCommand({
     TableName: process.env.MESSAGES_TABLE!,
     IndexName: 'address-receivedAt-index',
-    KeyConditionExpression: '#address = :address',
+    KeyConditionExpression: keyConditionExpression,
     ExpressionAttributeNames: {
       '#address': 'address',
       ...expressionAttributeNames,

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -64,9 +64,9 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
     });
   }, [subscribe, address, direction]);
 
-  async function fetchMessages(cursor?: string, newFilters?: Filters) {
+  const fetchMessages = useCallback(async (cursor?: string, activeFilters?: Filters) => {
     setIsLoading(true);
-    const active = newFilters ?? filters;
+    const active = activeFilters ?? filters;
     const params = new URLSearchParams({ address, direction });
     if (active.sender) params.set('sender', active.sender);
     if (active.subject) params.set('subject', active.subject);
@@ -87,12 +87,12 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
     } finally {
       setIsLoading(false);
     }
-  }
+  }, [address, direction, filters]);
 
   const handleFilter = useCallback((newFilters: Filters) => {
     setFilters(newFilters);
     fetchMessages(undefined, newFilters);
-  }, []);
+  }, [fetchMessages]);
 
   function handleLoadMore() {
     if (nextCursor) fetchMessages(nextCursor);
@@ -115,7 +115,7 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
     <div className="space-y-4">
       <FilterBar onFilter={handleFilter} />
 
-      <Table>
+      <Table className={isLoading ? 'opacity-50 pointer-events-none' : ''}>
         <TableHeader>
           <TableRow>
             <TableHead className="w-8"></TableHead>

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -5,19 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90 active:bg-primary/80",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 active:bg-destructive/80",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground active:bg-accent/80",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 active:bg-secondary/70",
+        ghost: "hover:bg-accent hover:text-accent-foreground active:bg-accent/80",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/app/components/ui/date-picker.tsx
+++ b/app/components/ui/date-picker.tsx
@@ -27,6 +27,7 @@ export function DatePicker({ value, onChange, placeholder = 'Pick a date', class
     <Popover>
       <PopoverTrigger asChild>
         <Button
+          type="button"
           variant="outline"
           aria-label={ariaLabel}
           className={cn('h-8 w-40 justify-start text-left font-normal text-sm px-2', !value && 'text-muted-foreground', className)}


### PR DESCRIPTION
- From filter was querying non-existent DynamoDB attribute sender; messages are stored with from field so filter now searches from attribute
- Subject filter was lowercasing the search value before a case-sensitive DynamoDB contains call, making all subject searches return zero results
- Date filters were added to FilterExpression but receivedAt is the GSI sort key; DynamoDB rejects key attributes in FilterExpression causing a 500 on every date-filtered request. Moved date range into KeyConditionExpression using >= / <= / BETWEEN; before-date value now has T23:59:59.999Z appended so emails received on the selected day are included
- DatePicker button lacked type=button so it defaulted to type=submit inside the filter form, causing an accidental unfiltered search on every calendar open
- fetchMessages and handleFilter used useCallback with empty deps capturing a stale closure; converted fetchMessages to useCallback([address,direction,filters]) so handleFilter and handleLoadMore always use current filter state
- Added active:scale and active:bg states to Button variants for click feedback

closes #150