### PR TITLE
[feat]: fix drafts - per-address draft boxes and explicit save button…

### DIFF
--- a/app/__tests__/app/api/drafts/route.test.ts
+++ b/app/__tests__/app/api/drafts/route.test.ts
@@ -35,8 +35,14 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-function makeGetReq() {
-  return new NextRequest('http://localhost/api/drafts');
+function makeGetReq(params?: Record<string, string>) {
+  const url = new URL('http://localhost/api/drafts');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url.toString());
 }
 
 function makePostReq(body: Record<string, unknown> = {}) {
@@ -78,6 +84,21 @@ describe('GET /api/drafts', () => {
       TableName: 'hermes-drafts',
       FilterExpression: 'userId = :userId',
       ExpressionAttributeValues: { ':userId': 'user-42' },
+    });
+  });
+
+  test('filters by from address when ?from= param is provided', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-42' });
+    mockDynamoSend.mockResolvedValue({ Items: [] });
+
+    await GET(makeGetReq({ from: 'me@hermes.com' }));
+
+    const scanArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(scanArg).toMatchObject({
+      TableName: 'hermes-drafts',
+      FilterExpression: 'userId = :userId AND #from = :from',
+      ExpressionAttributeValues: { ':userId': 'user-42', ':from': 'me@hermes.com' },
+      ExpressionAttributeNames: { '#from': 'from' },
     });
   });
 

--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -86,13 +86,30 @@ describe('Sidebar', () => {
     expect(screen.getByText(/no addresses yet/i)).toBeInTheDocument();
   });
 
-  test('renders Compose, Addresses, Domains, Drafts, Settings links', () => {
+  test('renders Compose, Addresses, Domains, Settings links', () => {
     render(<Sidebar addresses={ADDRESSES} />);
     expect(screen.getByText('Compose')).toBeInTheDocument();
     expect(screen.getByText('Addresses')).toBeInTheDocument();
     expect(screen.getByText('Domains')).toBeInTheDocument();
-    expect(screen.getByText('Drafts')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  test('renders Drafts sub-nav for each address', () => {
+    render(<Sidebar addresses={ADDRESSES} />);
+    expect(screen.getAllByText('Drafts')).toHaveLength(ADDRESSES.length);
+  });
+
+  test('Drafts sub-link points to /drafts/[address]', () => {
+    render(<Sidebar addresses={ADDRESSES} />);
+    const draftsLinks = screen.getAllByRole('link', { name: /^drafts$/i });
+    expect(draftsLinks[0]).toHaveAttribute('href', '/drafts/hello%40example.com');
+  });
+
+  test('Drafts sub-link has active style when on drafts route', () => {
+    mockPathname.mockReturnValue('/drafts/hello%40example.com');
+    render(<Sidebar addresses={ADDRESSES} />);
+    const draftsLinks = screen.getAllByRole('link', { name: /^drafts$/i });
+    expect(draftsLinks[0].firstElementChild?.className).toContain('bg-accent');
   });
 
   test('Addresses link points to /addresses', () => {

--- a/app/__tests__/components/messages/compose-sheet.test.tsx
+++ b/app/__tests__/components/messages/compose-sheet.test.tsx
@@ -4,6 +4,11 @@ import { ComposeSheet } from '@/components/messages/compose-sheet';
 import { ComposeProvider } from '@/components/compose-context';
 import { useCompose } from '@/components/compose-context';
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+  usePathname: () => '/',
+}));
+
 jest.mock('@/components/ui/sheet', () => ({
   Sheet: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
     open ? <div data-testid="sheet-root">{children}</div> : null,
@@ -42,24 +47,16 @@ function TestWrapper({ initialData }: { initialData?: Parameters<ReturnType<type
 
 beforeEach(() => {
   global.fetch = jest.fn();
-  jest.useFakeTimers();
 });
 
 afterEach(() => {
   jest.clearAllMocks();
-  jest.useRealTimers();
 });
-
-async function advanceAutoSave() {
-  await act(async () => {
-    jest.advanceTimersByTime(10_000);
-  });
-}
 
 describe('ComposeSheet', () => {
   describe('From dropdown', () => {
     test('shows only active (non-deleted) addresses in From dropdown', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -69,7 +66,7 @@ describe('ComposeSheet', () => {
     });
 
     test('defaults From to first active address', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -80,7 +77,7 @@ describe('ComposeSheet', () => {
 
   describe('email validation', () => {
     test('shows validation error for invalid email in To field', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -94,7 +91,7 @@ describe('ComposeSheet', () => {
     });
 
     test('shows validation error for invalid email in Cc field', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -113,7 +110,7 @@ describe('ComposeSheet', () => {
         ok: true,
         json: async () => ({ messageId: 'new-msg' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -127,30 +124,27 @@ describe('ComposeSheet', () => {
     });
   });
 
-  describe('auto-save', () => {
-    test('shows Saving… indicator while save is in-flight', async () => {
-      (global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}));
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  describe('save draft button', () => {
+    test('shows Save Draft button in compose form', async () => {
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
-      await user.type(screen.getByTestId('compose-body'), 'Hello');
-      await advanceAutoSave();
 
-      expect(screen.getByTestId('save-status-saving')).toBeInTheDocument();
+      expect(screen.getByTestId('compose-save-draft-button')).toBeInTheDocument();
     });
 
-    test('calls POST /api/drafts on first auto-save', async () => {
+    test('calls POST /api/drafts when Save Draft is clicked for a new draft', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: async () => ({ draftId: 'draft-new' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
       await user.type(screen.getByTestId('compose-body'), 'Hello');
-      await advanceAutoSave();
+      await user.click(screen.getByTestId('compose-save-draft-button'));
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
@@ -160,7 +154,45 @@ describe('ComposeSheet', () => {
       });
     });
 
-    test('shows Draft saved indicator after successful save', async () => {
+    test('shows Draft saved indicator after Save Draft is clicked', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-new' }),
+      });
+      const user = userEvent.setup();
+      render(<TestWrapper />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await user.click(screen.getByTestId('compose-save-draft-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('save-status-saved')).toBeInTheDocument();
+      });
+    });
+
+    test('calls PUT /api/drafts/:id when Save Draft is clicked with an existing draft', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-existing' }),
+      });
+      const user = userEvent.setup();
+      render(<TestWrapper initialData={{ draftId: 'draft-existing' }} />);
+
+      await user.click(screen.getByTestId('open-compose'));
+      await user.type(screen.getByTestId('compose-body'), 'Hello');
+      await user.click(screen.getByTestId('compose-save-draft-button'));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/drafts/draft-existing',
+          expect.objectContaining({ method: 'PUT' }),
+        );
+      });
+    });
+
+    test('does not auto-save when fields change', async () => {
+      jest.useFakeTimers();
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: async () => ({ draftId: 'draft-new' }),
@@ -170,31 +202,13 @@ describe('ComposeSheet', () => {
 
       await user.click(screen.getByTestId('open-compose'));
       await user.type(screen.getByTestId('compose-body'), 'Hello');
-      await advanceAutoSave();
+      await act(async () => { jest.advanceTimersByTime(30_000); });
 
-      await waitFor(() => {
-        expect(screen.getByTestId('save-status-saved')).toBeInTheDocument();
-      });
-    });
-
-    test('calls PUT /api/drafts/:id on subsequent saves when initialDraftId is provided', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => ({ draftId: 'draft-existing' }),
-      });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-      render(<TestWrapper initialData={{ draftId: 'draft-existing' }} />);
-
-      await user.click(screen.getByTestId('open-compose'));
-      await user.type(screen.getByTestId('compose-body'), 'Hello');
-      await advanceAutoSave();
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(
-          '/api/drafts/draft-existing',
-          expect.objectContaining({ method: 'PUT' }),
-        );
-      });
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        '/api/drafts',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      jest.useRealTimers();
     });
   });
 
@@ -204,7 +218,7 @@ describe('ComposeSheet', () => {
         ok: true,
         json: async () => ({ messageId: 'new-msg' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -225,7 +239,7 @@ describe('ComposeSheet', () => {
         ok: true,
         json: async () => ({ messageId: 'new-msg' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -243,7 +257,7 @@ describe('ComposeSheet', () => {
         ok: false,
         json: async () => ({ error: 'Send failed' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -260,7 +274,7 @@ describe('ComposeSheet', () => {
   describe('discard', () => {
     test('calls DELETE /api/drafts/:id when draftId exists', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper initialData={{ draftId: 'draft-abc' }} />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -275,7 +289,7 @@ describe('ComposeSheet', () => {
     });
 
     test('closes sheet on discard without draft', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<TestWrapper />);
 
       await user.click(screen.getByTestId('open-compose'));
@@ -291,7 +305,7 @@ describe('ComposeSheet', () => {
 
   describe('restoring draft fields', () => {
     test('restores all fields from initialData', async () => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(
         <TestWrapper
           initialData={{

--- a/app/__tests__/components/messages/reply-composer.test.tsx
+++ b/app/__tests__/components/messages/reply-composer.test.tsx
@@ -2,6 +2,11 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReplyComposer } from '@/components/messages/reply-composer';
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+  usePathname: () => '/',
+}));
+
 const BASE_MESSAGE = {
   messageId: 'msg-1',
   subject: 'Hello there',
@@ -18,19 +23,11 @@ const DEFAULT_PROPS = {
 
 beforeEach(() => {
   global.fetch = jest.fn();
-  jest.useFakeTimers();
 });
 
 afterEach(() => {
   jest.clearAllMocks();
-  jest.useRealTimers();
 });
-
-async function advanceAutoSave() {
-  await act(async () => {
-    jest.advanceTimersByTime(10_000);
-  });
-}
 
 describe('ReplyComposer', () => {
   describe('pre-filled fields', () => {
@@ -76,28 +73,22 @@ describe('ReplyComposer', () => {
     });
   });
 
-  describe('auto-save', () => {
-    test('shows Saving… indicator while fetch is in-flight', async () => {
-      (global.fetch as jest.Mock).mockReturnValue(new Promise(() => {}));
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  describe('save draft button', () => {
+    test('shows Save Draft button', () => {
       render(<ReplyComposer {...DEFAULT_PROPS} />);
-
-      await user.type(screen.getByTestId('reply-body'), 'Hello');
-      await advanceAutoSave();
-
-      expect(screen.getByTestId('save-status-saving')).toBeInTheDocument();
+      expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
     });
 
-    test('calls POST /api/drafts on first auto-save', async () => {
+    test('calls POST /api/drafts when Save Draft is clicked for a new draft', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: async () => ({ draftId: 'draft-abc' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       await user.type(screen.getByTestId('reply-body'), 'Hello');
-      await advanceAutoSave();
+      await user.click(screen.getByTestId('save-draft-button'));
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
@@ -107,32 +98,32 @@ describe('ReplyComposer', () => {
       });
     });
 
-    test('shows Draft saved indicator after successful save', async () => {
+    test('shows Draft saved indicator after Save Draft is clicked', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: async () => ({ draftId: 'draft-abc' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       await user.type(screen.getByTestId('reply-body'), 'Hello');
-      await advanceAutoSave();
+      await user.click(screen.getByTestId('save-draft-button'));
 
       await waitFor(() => {
         expect(screen.getByTestId('save-status-saved')).toBeInTheDocument();
       });
     });
 
-    test('calls PUT /api/drafts/:id on subsequent auto-saves', async () => {
+    test('calls PUT /api/drafts/:id when Save Draft is clicked with an existing draft', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: async () => ({ draftId: 'draft-existing' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} initialDraftId="draft-existing" />);
 
       await user.type(screen.getByTestId('reply-body'), 'Hello');
-      await advanceAutoSave();
+      await user.click(screen.getByTestId('save-draft-button'));
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
@@ -141,12 +132,31 @@ describe('ReplyComposer', () => {
         );
       });
     });
+
+    test('does not auto-save when fields change', async () => {
+      jest.useFakeTimers();
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ draftId: 'draft-abc' }),
+      });
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(<ReplyComposer {...DEFAULT_PROPS} />);
+
+      await user.type(screen.getByTestId('reply-body'), 'Hello');
+      await act(async () => { jest.advanceTimersByTime(30_000); });
+
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        '/api/drafts',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      jest.useRealTimers();
+    });
   });
 
   describe('send', () => {
     test('calls POST /api/messages/:id/reply on Send click', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ messageId: 'new-msg' }) });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       await user.click(screen.getByTestId('send-button'));
@@ -162,7 +172,7 @@ describe('ReplyComposer', () => {
     test('calls onClose after successful send', async () => {
       const onClose = jest.fn();
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ messageId: 'new-msg' }) });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} onClose={onClose} />);
 
       await user.click(screen.getByTestId('send-button'));
@@ -177,7 +187,7 @@ describe('ReplyComposer', () => {
         ok: false,
         json: async () => ({ error: 'Failed to send' }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       await user.click(screen.getByTestId('send-button'));
@@ -197,7 +207,7 @@ describe('ReplyComposer', () => {
   describe('discard', () => {
     test('calls DELETE /api/drafts/:id on discard when draftId exists', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} initialDraftId="draft-xyz" />);
 
       await user.click(screen.getByTestId('discard-button'));
@@ -212,7 +222,7 @@ describe('ReplyComposer', () => {
 
     test('calls onClose on discard without draft', async () => {
       const onClose = jest.fn();
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} onClose={onClose} />);
 
       await user.click(screen.getByTestId('discard-button'));
@@ -237,7 +247,7 @@ describe('ReplyComposer', () => {
           size: 1024,
         }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       const file = new File(['content'], 'report.pdf', { type: 'application/pdf' });
@@ -259,7 +269,7 @@ describe('ReplyComposer', () => {
           size: 512,
         }),
       });
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const user = userEvent.setup();
       render(<ReplyComposer {...DEFAULT_PROPS} />);
 
       await user.upload(screen.getByTestId('file-input'), new File(['content'], 'doc.pdf', { type: 'application/pdf' }));

--- a/app/app/(app)/drafts/[address]/page.tsx
+++ b/app/app/(app)/drafts/[address]/page.tsx
@@ -1,0 +1,55 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { DraftsList } from '@/components/drafts/drafts-list';
+
+interface Draft {
+  draftId: string;
+  from?: string;
+  to?: string;
+  subject?: string;
+  body?: string;
+  cc?: string;
+  bcc?: string;
+  attachmentKeys?: string[];
+  inReplyToMessageId?: string;
+  updatedAt: string;
+}
+
+async function getDrafts(address: string): Promise<Draft[]> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('access_token')?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const res = await fetch(
+    `${baseUrl}/api/drafts?from=${encodeURIComponent(address)}`,
+    {
+      headers: { Cookie: `access_token=${token}` },
+      cache: 'no-store',
+    },
+  );
+
+  if (res.status === 401) {
+    redirect('/login');
+  }
+
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  return data.drafts ?? [];
+}
+
+export default async function AddressDraftsPage({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}) {
+  const { address } = await params;
+  const decoded = decodeURIComponent(address);
+  const drafts = await getDrafts(decoded);
+
+  return <DraftsList drafts={drafts} />;
+}

--- a/app/app/api/drafts/route.ts
+++ b/app/app/api/drafts/route.ts
@@ -18,11 +18,24 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
+  const fromFilter = req.nextUrl.searchParams.get('from');
+
   const dynamo = getDynamo();
+  const filterParts = ['userId = :userId'];
+  const exprValues: Record<string, unknown> = { ':userId': claims.sub };
+  const exprNames: Record<string, string> = {};
+
+  if (fromFilter) {
+    filterParts.push('#from = :from');
+    exprNames['#from'] = 'from';
+    exprValues[':from'] = fromFilter;
+  }
+
   const result = await dynamo.send(new ScanCommand({
     TableName: process.env.DRAFTS_TABLE!,
-    FilterExpression: 'userId = :userId',
-    ExpressionAttributeValues: { ':userId': claims.sub },
+    FilterExpression: filterParts.join(' AND '),
+    ExpressionAttributeValues: exprValues,
+    ...(Object.keys(exprNames).length > 0 ? { ExpressionAttributeNames: exprNames } : {}),
   }));
 
   const drafts = (result.Items ?? []).sort((a, b) => {

--- a/app/components/drafts/drafts-list.tsx
+++ b/app/components/drafts/drafts-list.tsx
@@ -57,7 +57,7 @@ export function DraftsList({ drafts }: DraftsListProps) {
         <FileText className="h-10 w-10 text-muted-foreground" />
         <p className="text-sm text-muted-foreground">No drafts saved yet.</p>
         <p className="text-xs text-muted-foreground">
-          Drafts are saved automatically as you compose or reply.
+          Click &quot;Save Draft&quot; in the compose or reply dialog to save a draft here.
         </p>
       </div>
     );

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -10,7 +10,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useWs } from '@/components/ws-context';
 import { useCompose } from '@/components/compose-context';
 
-import { Mail, FileText, Settings, LogOut, PenSquare, Globe, AtSign, Inbox, Send, Loader2 } from 'lucide-react';
+import { Mail, Settings, LogOut, PenSquare, Globe, AtSign, Inbox, Send, Loader2, BookMarked } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -116,9 +116,11 @@ export function Sidebar({ addresses }: SidebarProps) {
             {addresses.map((addr) => {
               const inboxHref = `/inbox/${encodeURIComponent(addr.email)}`;
               const sentHref = `/sent/${encodeURIComponent(addr.email)}`;
+              const draftsHref = `/drafts/${encodeURIComponent(addr.email)}`;
               const inboxActive = pathname.startsWith(inboxHref);
               const sentActive = pathname.startsWith(sentHref);
-              const isAddressActive = inboxActive || sentActive;
+              const draftsActive = pathname.startsWith(draftsHref);
+              const isAddressActive = inboxActive || sentActive || draftsActive;
               const count = unreadCounts.get(addr.email) ?? 0;
               return (
                 <li key={addr.email}>
@@ -154,6 +156,11 @@ export function Sidebar({ addresses }: SidebarProps) {
                         <NavLinkInner icon={Send} label="Sent" isActive={sentActive} size="sm" />
                       </Link>
                     </li>
+                    <li>
+                      <Link href={draftsHref} className="block">
+                        <NavLinkInner icon={BookMarked} label="Drafts" isActive={draftsActive} size="sm" />
+                      </Link>
+                    </li>
                   </ul>
                 </li>
               );
@@ -174,11 +181,6 @@ export function Sidebar({ addresses }: SidebarProps) {
             <li>
               <Link href="/domains" className="block">
                 <NavLinkInner icon={Globe} label="Domains" isActive={pathname === '/domains'} />
-              </Link>
-            </li>
-            <li>
-              <Link href="/drafts" className="block">
-                <NavLinkInner icon={FileText} label="Drafts" isActive={pathname === '/drafts'} />
               </Link>
             </li>
             <li>

--- a/app/components/messages/compose-sheet.tsx
+++ b/app/components/messages/compose-sheet.tsx
@@ -17,7 +17,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { Paperclip, Send, Trash2, X } from 'lucide-react';
+import { BookMarked, Paperclip, Send, Trash2, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useCompose, type ComposeInitialData } from '@/components/compose-context';
 
 interface Address {
@@ -69,6 +70,7 @@ interface ComposeSheetInnerProps {
 }
 
 function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInnerProps) {
+  const router = useRouter();
   const activeAddresses = addresses.filter((a) => a.status !== 'deleted');
 
   const form = useForm<ComposeFormValues>({
@@ -91,19 +93,12 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
   const [sendError, setSendError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const draftIdRef = useRef<string | null>(draftId);
 
   useEffect(() => {
     draftIdRef.current = draftId;
   }, [draftId]);
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
 
   async function saveDraft(payload: Record<string, unknown>, existingDraftId: string | null): Promise<string | null> {
     setSaveStatus('saving');
@@ -139,28 +134,21 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
     }
   }
 
-  function scheduleSave(payload: Record<string, unknown>) {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      saveDraft(payload, draftIdRef.current);
-    }, 10_000);
-  }
-
-  function buildPayload(values: Partial<ComposeFormValues>) {
+  function buildPayload() {
     const current = form.getValues();
     return {
-      from: values.from ?? current.from,
-      to: values.to ?? current.to,
-      cc: (values.cc ?? current.cc) || undefined,
-      bcc: (values.bcc ?? current.bcc) || undefined,
-      subject: values.subject ?? current.subject,
-      body: values.body ?? current.body,
+      from: current.from,
+      to: current.to,
+      cc: current.cc || undefined,
+      bcc: current.bcc || undefined,
+      subject: current.subject,
+      body: current.body,
       attachmentKeys: attachments.map((a) => a.s3Key),
     };
   }
 
-  function handleFieldChange(field: keyof ComposeFormValues, value: string) {
-    scheduleSave(buildPayload({ [field]: value }));
+  async function handleSaveDraft() {
+    await saveDraft(buildPayload(), draftIdRef.current);
   }
 
   async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
@@ -185,7 +173,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
   }
 
   async function handleSend(values: ComposeFormValues) {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
     setIsSending(true);
     setSendError(null);
     try {
@@ -209,6 +196,7 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
         return;
       }
       onClose();
+      router.refresh();
     } catch {
       setSendError('Failed to send email. Please try again.');
     } finally {
@@ -217,11 +205,11 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
   }
 
   async function handleDiscard() {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
     if (draftIdRef.current) {
       await fetch(`/api/drafts/${draftIdRef.current}`, { method: 'DELETE' }).catch(() => null);
     }
     onClose();
+    router.refresh();
   }
 
   function formatSavedAt(date: Date) {
@@ -234,9 +222,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
         <div className="flex items-center justify-between pr-8">
           <SheetTitle>New Message</SheetTitle>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {saveStatus === 'saving' && (
-              <span data-testid="save-status-saving">Saving…</span>
-            )}
             {saveStatus === 'saved' && savedAt && (
               <span data-testid="save-status-saved">
                 Draft saved {formatSavedAt(savedAt)}
@@ -263,7 +248,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                     value={field.value}
                     onValueChange={(val) => {
                       field.onChange(val);
-                      handleFieldChange('from', val);
                     }}
                   >
                     <FormControl>
@@ -296,7 +280,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                       placeholder="recipient@example.com"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleFieldChange('to', e.target.value);
                       }}
                       data-testid="compose-to"
                     />
@@ -318,7 +301,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                       placeholder="cc@example.com"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleFieldChange('cc', e.target.value);
                       }}
                       data-testid="compose-cc"
                     />
@@ -340,7 +322,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                       placeholder="bcc@example.com"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleFieldChange('bcc', e.target.value);
                       }}
                       data-testid="compose-bcc"
                     />
@@ -362,7 +343,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                       placeholder="Subject"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleFieldChange('subject', e.target.value);
                       }}
                       data-testid="compose-subject"
                     />
@@ -385,7 +365,6 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                       className="min-h-[200px] resize-y"
                       onChange={(e) => {
                         field.onChange(e);
-                        handleFieldChange('body', e.target.value);
                       }}
                       data-testid="compose-body"
                     />
@@ -449,6 +428,18 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
               </div>
 
               <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={handleSaveDraft}
+                  disabled={saveStatus === 'saving'}
+                  className="gap-1"
+                  data-testid="compose-save-draft-button"
+                >
+                  <BookMarked className="h-3.5 w-3.5" />
+                  {saveStatus === 'saving' ? 'Saving…' : 'Save Draft'}
+                </Button>
                 <Button
                   type="button"
                   size="sm"

--- a/app/components/messages/reply-composer.tsx
+++ b/app/components/messages/reply-composer.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { Paperclip, Send, Trash2, X } from 'lucide-react';
+import { BookMarked, Paperclip, Send, Trash2, X } from 'lucide-react';
 
 interface Message {
   messageId: string;
@@ -60,6 +61,7 @@ export function ReplyComposer({
   initialBody,
   onClose,
 }: ReplyComposerProps) {
+  const router = useRouter();
   const originalSubject = message.subject ?? '';
   const reSubject = originalSubject.toLowerCase().startsWith('re:')
     ? originalSubject
@@ -80,7 +82,6 @@ export function ReplyComposer({
   const [sendError, setSendError] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function saveDraft(draftPayload: Record<string, unknown>, existingDraftId: string | null): Promise<string | null> {
@@ -117,47 +118,19 @@ export function ReplyComposer({
     }
   }
 
-  function scheduleSave(currentDraftId: string | null, payload: Record<string, unknown>) {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      saveDraft(payload, currentDraftId);
-    }, 10_000);
-  }
-
-  function handleBodyChange(value: string) {
-    setBody(value);
-    scheduleSave(draftId, {
+  function buildPayload() {
+    return {
       from: currentAddress,
       to,
-      cc: cc || undefined,
-      body: value,
-      attachmentKeys: attachments.map((a) => a.s3Key),
-      inReplyToMessageId: message.messageId,
-    });
-  }
-
-  function handleToChange(value: string) {
-    setTo(value);
-    scheduleSave(draftId, {
-      from: currentAddress,
-      to: value,
       cc: cc || undefined,
       body,
       attachmentKeys: attachments.map((a) => a.s3Key),
       inReplyToMessageId: message.messageId,
-    });
+    };
   }
 
-  function handleCcChange(value: string) {
-    setCc(value);
-    scheduleSave(draftId, {
-      from: currentAddress,
-      to,
-      cc: value || undefined,
-      body,
-      attachmentKeys: attachments.map((a) => a.s3Key),
-      inReplyToMessageId: message.messageId,
-    });
+  async function handleSaveDraft() {
+    await saveDraft(buildPayload(), draftId);
   }
 
   async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
@@ -183,7 +156,6 @@ export function ReplyComposer({
   }
 
   async function handleSend() {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
     setIsSending(true);
     setSendError(null);
     try {
@@ -205,6 +177,7 @@ export function ReplyComposer({
         return;
       }
       onClose();
+      router.refresh();
     } catch {
       setSendError('Failed to send reply. Please try again.');
     } finally {
@@ -213,18 +186,12 @@ export function ReplyComposer({
   }
 
   async function handleDiscard() {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
     if (draftId) {
       await fetch(`/api/drafts/${draftId}`, { method: 'DELETE' }).catch(() => null);
     }
     onClose();
+    router.refresh();
   }
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
 
   function formatSavedAt(date: Date) {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -238,9 +205,6 @@ export function ReplyComposer({
             <span className="text-sm font-medium">
               {replyAll ? 'Reply All' : 'Reply'}
             </span>
-            {saveStatus === 'saving' && (
-              <span className="text-xs text-muted-foreground" data-testid="save-status-saving">Saving…</span>
-            )}
             {saveStatus === 'saved' && savedAt && (
               <span className="text-xs text-muted-foreground" data-testid="save-status-saved">
                 Draft saved {formatSavedAt(savedAt)}
@@ -271,7 +235,7 @@ export function ReplyComposer({
           <Input
             id="reply-to"
             value={to}
-            onChange={(e) => handleToChange(e.target.value)}
+            onChange={(e) => setTo(e.target.value)}
             placeholder="recipient@example.com"
             data-testid="reply-to"
           />
@@ -283,7 +247,7 @@ export function ReplyComposer({
             <Input
               id="reply-cc"
               value={cc}
-              onChange={(e) => handleCcChange(e.target.value)}
+              onChange={(e) => setCc(e.target.value)}
               placeholder="cc@example.com"
               data-testid="reply-cc"
             />
@@ -295,7 +259,7 @@ export function ReplyComposer({
           <Textarea
             id="reply-body"
             value={body}
-            onChange={(e) => handleBodyChange(e.target.value)}
+            onChange={(e) => setBody(e.target.value)}
             placeholder="Write your reply…"
             className="min-h-[160px] resize-y"
             data-testid="reply-body"
@@ -352,6 +316,17 @@ export function ReplyComposer({
           </div>
 
           <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleSaveDraft}
+              disabled={saveStatus === 'saving'}
+              className="gap-1"
+              data-testid="save-draft-button"
+            >
+              <BookMarked className="h-3.5 w-3.5" />
+              {saveStatus === 'saving' ? 'Saving…' : 'Save Draft'}
+            </Button>
             <Button
               size="sm"
               variant="ghost"


### PR DESCRIPTION
… (#154)

- Move Drafts nav link under each address (alongside Inbox/Sent), routing to /drafts/[address]
- Add per-address drafts page that filters drafts by from address
- Extend GET /api/drafts to accept optional ?from= query param
- Replace auto-save debounce with explicit Save Draft button in compose sheet and reply composer
- Call router.refresh() after send/discard so draft list updates without a page reload
- Update all affected tests

closes #154