### PR TITLE
[feat]: implement Junk folder (#168)

### DIFF
--- a/app/__tests__/app/api/messages/[id]/route.test.ts
+++ b/app/__tests__/app/api/messages/[id]/route.test.ts
@@ -319,7 +319,7 @@ describe('PATCH /api/messages/:id', () => {
     expect(body.error).toBe('Message not found');
   });
 
-  test('returns 400 when isRead is missing', async () => {
+  test('returns 400 when neither isRead nor folder is provided', async () => {
     const res = await PATCH(makePatchReq('msg-1', {}), makeParams('msg-1'));
     const body = await res.json();
 
@@ -333,6 +333,48 @@ describe('PATCH /api/messages/:id', () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toContain('isRead');
+  });
+
+  test('moves message to junk folder', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: EXISTING_ITEM });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, folder: 'junk' } });
+
+    const res = await PATCH(makePatchReq('msg-1', { folder: 'junk' }), makeParams('msg-1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message.folder).toBe('junk');
+  });
+
+  test('restores message to inbox folder', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: { ...EXISTING_ITEM, folder: 'junk' } });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, folder: 'inbox' } });
+
+    const res = await PATCH(makePatchReq('msg-1', { folder: 'inbox' }), makeParams('msg-1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message.folder).toBe('inbox');
+  });
+
+  test('returns 400 for invalid folder value', async () => {
+    const res = await PATCH(makePatchReq('msg-1', { folder: 'spam' }), makeParams('msg-1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('folder');
+  });
+
+  test('updates both isRead and folder in a single request', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: EXISTING_ITEM });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: true, folder: 'junk' } });
+
+    const res = await PATCH(makePatchReq('msg-1', { isRead: true, folder: 'junk' }), makeParams('msg-1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message.isRead).toBe(true);
+    expect(body.message.folder).toBe('junk');
   });
 
   test('returns 400 for invalid JSON body', async () => {

--- a/app/__tests__/app/api/messages/route.test.ts
+++ b/app/__tests__/app/api/messages/route.test.ts
@@ -240,6 +240,41 @@ describe('GET /api/messages', () => {
     expect(queryArg.FilterExpression).toBeUndefined();
   });
 
+  test('folder=junk filters by folder attribute only', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+
+    await GET(makeGetReq({ address: 'inbox@example.com', folder: 'junk' }));
+
+    const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(queryArg.FilterExpression).toContain('#folder = :folder');
+    expect(queryArg.ExpressionAttributeValues).toMatchObject({ ':folder': 'junk' });
+    expect(queryArg.FilterExpression).not.toContain('#direction');
+  });
+
+  test('folder=inbox filters by direction=inbound and folder=inbox or missing', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+
+    await GET(makeGetReq({ address: 'inbox@example.com', folder: 'inbox' }));
+
+    const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(queryArg.FilterExpression).toContain('#direction = :inbound');
+    expect(queryArg.FilterExpression).toContain('attribute_not_exists(#folder)');
+    expect(queryArg.ExpressionAttributeValues).toMatchObject({ ':inbound': 'inbound', ':folder': 'inbox' });
+  });
+
+  test('folder param takes precedence over direction param', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });
+
+    await GET(makeGetReq({ address: 'inbox@example.com', folder: 'junk', direction: 'inbound' }));
+
+    const queryArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(queryArg.FilterExpression).toContain('#folder = :folder');
+    expect(queryArg.FilterExpression).not.toContain('#direction = :direction');
+  });
+
   test('defaults limit to 20', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     mockDynamoSend.mockResolvedValue({ Items: [], LastEvaluatedKey: undefined });

--- a/app/__tests__/components/inbox/message-list.test.tsx
+++ b/app/__tests__/components/inbox/message-list.test.tsx
@@ -282,6 +282,72 @@ describe('MessageList — hermes:inboxcount', () => {
   });
 });
 
+describe('MessageList — folder prop (junk)', () => {
+  const JUNK_PROPS = {
+    address: 'hello@example.com',
+    direction: 'inbound' as const,
+    folder: 'junk' as const,
+    initialMessages: INBOUND_MESSAGES,
+    initialNextCursor: null,
+    folderLabel: 'Junk',
+  };
+
+  test('renders Junk folder label', () => {
+    render(<MessageList {...JUNK_PROPS} />);
+    expect(screen.getByText('Junk')).toBeInTheDocument();
+  });
+
+  test('navigates to /junk/[address]/[messageId] on row click', async () => {
+    const { useRouter } = require('next/navigation');
+    const mockPush = jest.fn();
+    useRouter.mockReturnValue({ push: mockPush });
+    const user = userEvent.setup();
+    render(<MessageList {...JUNK_PROPS} />);
+    await user.click(screen.getByTestId('message-row-msg-1'));
+    expect(mockPush).toHaveBeenCalledWith('/junk/hello%40example.com/msg-1');
+  });
+
+  test('passes folder=junk to API on pagination', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [], nextCursor: null }),
+    });
+    const user = userEvent.setup();
+    render(<MessageList {...JUNK_PROPS} initialNextCursor="cursor1" />);
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('folder=junk'));
+    });
+  });
+
+  test('does not subscribe to WebSocket events for junk folder', () => {
+    render(<MessageList {...JUNK_PROPS} />);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  test('does not dispatch hermes:inboxcount for junk folder', () => {
+    const events: CustomEvent[] = [];
+    const handler = (e: Event) => events.push(e as CustomEvent);
+    window.addEventListener('hermes:inboxcount', handler);
+    render(<MessageList {...JUNK_PROPS} />);
+    expect(events).toHaveLength(0);
+    window.removeEventListener('hermes:inboxcount', handler);
+  });
+
+  test('removes message from list when hermes:messageremoved fires', async () => {
+    render(<MessageList {...JUNK_PROPS} />);
+    expect(screen.getByText('alice@test.com')).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('hermes:messageremoved', { detail: { messageId: 'msg-1' } }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('alice@test.com')).not.toBeInTheDocument();
+    });
+  });
+});
+
 describe('MessageList — card layout', () => {
   test('renders message snippet when provided', () => {
     const msgs = [{ ...INBOUND_MESSAGES[0], snippet: 'This is a preview of the email body' }];

--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -9,6 +9,17 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
 }));
 
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastInfo = jest.fn();
+jest.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    info: (...args: unknown[]) => mockToastInfo(...args),
+  },
+}));
+
 
 beforeEach(() => {
   global.fetch = jest.fn();
@@ -151,5 +162,78 @@ describe('MessageDetail', () => {
     await user.click(screen.getByRole('button', { name: /reply all/i }));
     expect(screen.getByTestId('reply-composer')).toBeInTheDocument();
     expect(screen.getByTestId('reply-cc')).toBeInTheDocument();
+  });
+
+  test('dispatches hermes:messageremoved after delete', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const events: CustomEvent[] = [];
+    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => {
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+    });
+    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  });
+});
+
+describe('MessageDetail — junk folder', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    mockPathname.mockReturnValue('/junk/test%40example.com/msg-1');
+  });
+
+  test('shows Restore to Inbox button when in junk folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.getByRole('button', { name: /restore to inbox/i })).toBeInTheDocument();
+  });
+
+  test('does not show Move to Junk button when in junk folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.queryByRole('button', { name: /move to junk/i })).not.toBeInTheDocument();
+  });
+
+  test('shows read toggle when in junk folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.getByRole('button', { name: /mark as (un)?read/i })).toBeInTheDocument();
+  });
+
+  test('calls PATCH with folder=inbox on Restore to Inbox click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/messages/msg-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'inbox' }) }),
+      );
+    });
+  });
+
+  test('dispatches hermes:messageremoved after Restore to Inbox', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const events: CustomEvent[] = [];
+    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+    });
+    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  });
+
+  test('calls toast.error when Restore to Inbox fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/failed to restore/i));
+    });
   });
 });

--- a/app/app/(app)/junk/[address]/[messageId]/page.tsx
+++ b/app/app/(app)/junk/[address]/[messageId]/page.tsx
@@ -1,0 +1,82 @@
+import { cookies } from 'next/headers';
+import { redirect, notFound } from 'next/navigation';
+import { MessageDetail } from '@/components/messages/message-detail';
+
+interface Attachment {
+  filename: string;
+  url: string;
+  contentType?: string;
+  size?: number;
+}
+
+interface Message {
+  messageId: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+  subject: string;
+  receivedAt: string;
+  isRead: boolean;
+  bodyHtmlUrl?: string;
+  bodyTextUrl?: string;
+  attachments?: Attachment[];
+}
+
+async function getMessage(id: string): Promise<Message | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('access_token')?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/messages/${encodeURIComponent(id)}`, {
+    headers: { Cookie: `access_token=${token}` },
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login');
+  }
+
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+
+  const data = await res.json();
+  return data.message ?? null;
+}
+
+async function fetchBodyFromS3(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    return res.ok ? res.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+interface Props {
+  params: Promise<{ address: string; messageId: string }>;
+}
+
+export default async function JunkMessageDetailPage({ params }: Props) {
+  const { messageId } = await params;
+  const message = await getMessage(messageId);
+
+  if (!message) {
+    notFound();
+  }
+
+  const htmlBody = message.bodyHtmlUrl ? await fetchBodyFromS3(message.bodyHtmlUrl) : null;
+  const textBody = !htmlBody && message.bodyTextUrl ? await fetchBodyFromS3(message.bodyTextUrl) : null;
+
+  return (
+    <MessageDetail
+      message={message}
+      initialHtmlBody={htmlBody}
+      initialTextBody={textBody}
+    />
+  );
+}

--- a/app/app/(app)/junk/[address]/layout.tsx
+++ b/app/app/(app)/junk/[address]/layout.tsx
@@ -22,7 +22,7 @@ async function getMessages(address: string) {
   if (!token) redirect('/login');
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
-  const params = new URLSearchParams({ address, folder: 'inbox' });
+  const params = new URLSearchParams({ address, folder: 'junk' });
   const res = await fetch(`${baseUrl}/api/messages?${params.toString()}`, {
     headers: { Cookie: `access_token=${token}` },
     cache: 'no-store',
@@ -39,7 +39,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export default async function InboxAddressLayout({ params, children }: Props) {
+export default async function JunkAddressLayout({ params, children }: Props) {
   const { address } = await params;
   const decodedAddress = decodeURIComponent(address);
   const { messages, nextCursor } = await getMessages(decodedAddress);
@@ -50,10 +50,10 @@ export default async function InboxAddressLayout({ params, children }: Props) {
         <MessageList
           address={decodedAddress}
           direction="inbound"
-          folder="inbox"
+          folder="junk"
           initialMessages={messages}
           initialNextCursor={nextCursor}
-          folderLabel="Inbox"
+          folderLabel="Junk"
         />
       }
       detail={children}

--- a/app/app/(app)/junk/[address]/page.tsx
+++ b/app/app/(app)/junk/[address]/page.tsx
@@ -1,12 +1,5 @@
-import { ComingSoonPane } from '@/components/messages/coming-soon-pane';
-import { MailboxLayout } from '@/components/layout/mailbox-layout';
 import { MailboxEmptyState } from '@/components/messages/mailbox-empty-state';
 
 export default function JunkPage() {
-  return (
-    <MailboxLayout
-      list={<ComingSoonPane label="Junk" />}
-      detail={<MailboxEmptyState />}
-    />
-  );
+  return <MailboxEmptyState />;
 }

--- a/app/app/api/messages/[id]/route.ts
+++ b/app/app/api/messages/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+const VALID_FOLDERS = ['inbox', 'junk', 'trash'] as const;
+type Folder = typeof VALID_FOLDERS[number];
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { requireAuth, AuthError } from '@/lib/auth/require-auth';
@@ -88,15 +91,26 @@ export async function PATCH(
   const { id } = await params;
 
   let isRead: unknown;
+  let folder: unknown;
   try {
     const body = await req.json();
     isRead = body?.isRead;
+    folder = body?.folder;
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
-  if (typeof isRead !== 'boolean') {
+  const hasIsRead = isRead !== undefined;
+  const hasFolder = folder !== undefined;
+
+  if (!hasIsRead && !hasFolder) {
+    return NextResponse.json({ error: 'At least one of isRead or folder must be provided' }, { status: 400 });
+  }
+  if (hasIsRead && typeof isRead !== 'boolean') {
     return NextResponse.json({ error: 'isRead must be a boolean' }, { status: 400 });
+  }
+  if (hasFolder && !VALID_FOLDERS.includes(folder as Folder)) {
+    return NextResponse.json({ error: `folder must be one of: ${VALID_FOLDERS.join(', ')}` }, { status: 400 });
   }
 
   const dynamo = getDynamo();
@@ -110,16 +124,29 @@ export async function PATCH(
     return NextResponse.json({ error: 'Message not found' }, { status: 404 });
   }
 
+  const setClauses: string[] = ['updatedAt = :now'];
+  const expressionAttributeNames: Record<string, string> = {};
+  const expressionAttributeValues: Record<string, unknown> = { ':now': new Date().toISOString() };
+
+  if (hasIsRead) {
+    setClauses.push('isRead = :isRead', '#status = :status');
+    expressionAttributeNames['#status'] = 'status';
+    expressionAttributeValues[':isRead'] = isRead;
+    expressionAttributeValues[':status'] = isRead ? 'read' : 'unread';
+  }
+
+  if (hasFolder) {
+    setClauses.push('#folder = :folder');
+    expressionAttributeNames['#folder'] = 'folder';
+    expressionAttributeValues[':folder'] = folder;
+  }
+
   const result = await dynamo.send(new UpdateCommand({
     TableName: process.env.MESSAGES_TABLE!,
     Key: { messageId: id },
-    UpdateExpression: 'SET isRead = :isRead, #status = :status, updatedAt = :now',
-    ExpressionAttributeNames: { '#status': 'status' },
-    ExpressionAttributeValues: {
-      ':isRead': isRead,
-      ':status': isRead ? 'read' : 'unread',
-      ':now': new Date().toISOString(),
-    },
+    UpdateExpression: `SET ${setClauses.join(', ')}`,
+    ...(Object.keys(expressionAttributeNames).length > 0 && { ExpressionAttributeNames: expressionAttributeNames }),
+    ExpressionAttributeValues: expressionAttributeValues,
     ReturnValues: 'ALL_NEW',
   }));
 

--- a/app/app/api/messages/route.ts
+++ b/app/app/api/messages/route.ts
@@ -53,6 +53,7 @@ export async function GET(req: NextRequest) {
   const from = searchParams.get('from');
   const to = searchParams.get('to');
   const direction = searchParams.get('direction');
+  const folder = searchParams.get('folder');
 
   const filterConditions: string[] = [];
   const expressionAttributeNames: Record<string, string> = {};
@@ -80,7 +81,20 @@ export async function GET(req: NextRequest) {
     expressionAttributeValues[':to'] = `${to}T23:59:59.999Z`;
   }
 
-  if (direction) {
+  if (folder === 'inbox') {
+    // Inbox: inbound messages not moved to junk/trash.
+    // attribute_not_exists handles legacy messages written before the folder field was added.
+    filterConditions.push('#direction = :inbound');
+    filterConditions.push('(#folder = :folder OR attribute_not_exists(#folder))');
+    expressionAttributeNames['#direction'] = 'direction';
+    expressionAttributeNames['#folder'] = 'folder';
+    expressionAttributeValues[':inbound'] = 'inbound';
+    expressionAttributeValues[':folder'] = 'inbox';
+  } else if (folder) {
+    filterConditions.push('#folder = :folder');
+    expressionAttributeNames['#folder'] = 'folder';
+    expressionAttributeValues[':folder'] = folder;
+  } else if (direction) {
     filterConditions.push('#direction = :direction');
     expressionAttributeNames['#direction'] = 'direction';
     expressionAttributeValues[':direction'] = direction;

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -29,6 +29,7 @@ interface Message {
 interface MessageListProps {
   address: string;
   direction: 'inbound' | 'outbound';
+  folder?: 'inbox' | 'junk' | 'trash';
   initialMessages: Message[];
   initialNextCursor: string | null;
   folderLabel: string;
@@ -36,7 +37,7 @@ interface MessageListProps {
 
 type Filter = 'all' | 'unread';
 
-export function MessageList({ address, direction, initialMessages, initialNextCursor, folderLabel }: MessageListProps) {
+export function MessageList({ address, direction, folder, initialMessages, initialNextCursor, folderLabel }: MessageListProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { subscribe } = useWs();
@@ -45,13 +46,15 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
   const [filter, setFilter] = useState<Filter>('all');
   const [isLoading, setIsLoading] = useState(false);
 
+  const isInboxFolder = folder === 'inbox' || (!folder && direction === 'inbound');
+
   const activeMessageId = (() => {
     const segments = pathname.split('/');
     return segments.length >= 4 ? segments[3] : null;
   })();
 
   useEffect(() => {
-    if (direction !== 'inbound') return;
+    if (!isInboxFolder) return;
     return subscribe((event) => {
       if (event.address.toLowerCase() !== address.toLowerCase()) return;
       // The WS payload only carries the messageId; fetch the full record.
@@ -67,7 +70,7 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
         })
         .catch(() => null);
     });
-  }, [subscribe, address, direction]);
+  }, [subscribe, address, isInboxFolder]);
 
   useEffect(() => {
     function onReadStatus(e: Event) {
@@ -81,16 +84,30 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
   }, []);
 
   useEffect(() => {
-    if (direction !== 'inbound') return;
+    function onMessageRemoved(e: Event) {
+      const { messageId } = (e as CustomEvent<{ messageId: string }>).detail;
+      setMessages((prev) => prev.filter((m) => m.messageId !== messageId));
+    }
+    window.addEventListener('hermes:messageremoved', onMessageRemoved);
+    return () => window.removeEventListener('hermes:messageremoved', onMessageRemoved);
+  }, []);
+
+  useEffect(() => {
+    if (!isInboxFolder) return;
     const unreadCount = messages.filter((m) => !m.isRead).length;
     window.dispatchEvent(
       new CustomEvent('hermes:inboxcount', { detail: { address, unreadCount } }),
     );
-  }, [messages, address, direction]);
+  }, [messages, address, isInboxFolder]);
 
   const fetchMessages = useCallback(async (cursor?: string) => {
     setIsLoading(true);
-    const params = new URLSearchParams({ address, direction });
+    const params = new URLSearchParams({ address });
+    if (folder) {
+      params.set('folder', folder);
+    } else {
+      params.set('direction', direction);
+    }
     if (cursor) params.set('cursor', cursor);
 
     try {
@@ -106,10 +123,10 @@ export function MessageList({ address, direction, initialMessages, initialNextCu
     } finally {
       setIsLoading(false);
     }
-  }, [address, direction]);
+  }, [address, direction, folder]);
 
   function handleRowClick(msg: Message) {
-    const root = direction === 'outbound' ? 'sent' : 'inbox';
+    const root = folder ?? (direction === 'outbound' ? 'sent' : 'inbox');
     router.push(`/${root}/${encodeURIComponent(address)}/${msg.messageId}`);
   }
 

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -14,6 +14,7 @@ import {
   Forward,
   MailOpen,
   Download,
+  Inbox,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ReplyComposer } from '@/components/messages/reply-composer';
@@ -105,12 +106,37 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
         toast.error('Failed to delete message');
         return;
       }
+      dispatchMessageRemoved(message.messageId);
       router.push(listHref);
       router.refresh();
     } catch {
       toast.error('Failed to delete message');
     } finally {
       setIsDeleting(false);
+    }
+  }
+
+  function dispatchMessageRemoved(messageId: string) {
+    window.dispatchEvent(new CustomEvent('hermes:messageremoved', { detail: { messageId } }));
+  }
+
+  async function handleRestoreToInbox() {
+    try {
+      const res = await fetch(`/api/messages/${message.messageId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder: 'inbox' }),
+      });
+      if (!res.ok) {
+        toast.error('Failed to restore message');
+        return;
+      }
+      dispatchMessageRemoved(message.messageId);
+      toast.success('Moved to Inbox');
+      router.push(listHref);
+      router.refresh();
+    } catch {
+      toast.error('Failed to restore message');
     }
   }
 
@@ -132,20 +158,37 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
 
         <TooltipProvider delayDuration={300}>
           <div className="flex items-center gap-1 shrink-0">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8"
-                  onClick={handleMoveToJunk}
-                  aria-label="Move to Junk"
-                >
-                  <AlertTriangle className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Move to Junk</TooltipContent>
-            </Tooltip>
+            {folder === 'junk' ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={handleRestoreToInbox}
+                    aria-label="Restore to Inbox"
+                  >
+                    <Inbox className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Restore to Inbox</TooltipContent>
+              </Tooltip>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={handleMoveToJunk}
+                    aria-label="Move to Junk"
+                  >
+                    <AlertTriangle className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Move to Junk</TooltipContent>
+              </Tooltip>
+            )}
 
             <Tooltip>
               <TooltipTrigger asChild>

--- a/infra/lambda/inbound-email-processor/index.js
+++ b/infra/lambda/inbound-email-processor/index.js
@@ -82,6 +82,7 @@ exports.handler = async (event) => {
       bodyHtmlS3Key: parsed.html ? `parsed/${messageId}/body.html` : undefined,
       snippet: (parsed.text || '').replace(/\s+/g, ' ').trim().slice(0, 300) || undefined,
       attachments: attachmentKeys,
+      folder: 'inbox',
       isRead: false,
     },
   }));


### PR DESCRIPTION
- Add folder field to inbound Lambda processor (folder: inbox)
- Extend GET /api/messages to filter by folder param; inbox uses direction=inbound AND (folder=inbox OR attribute_not_exists) to exclude messages moved to junk or trash
- Extend PATCH /api/messages/:id to accept folder updates alongside isRead; validates against allowed values (inbox, junk, trash)
- Add optional folder prop to MessageList for folder-aware routing and API params; add hermes:messageremoved listener for instant list updates after move or delete
- Add Restore to Inbox toolbar button in MessageDetail when viewing junk; dispatch hermes:messageremoved after restore and delete
- Create junk folder layout, page, and message detail route
- Update inbox layout to use folder=inbox param
- Add tests for all new behaviour (369 passing)

closes #168