### PR TITLE
[feat]: implement Trash folder (#169)

### DIFF
--- a/app/__tests__/components/inbox/message-list.test.tsx
+++ b/app/__tests__/components/inbox/message-list.test.tsx
@@ -348,6 +348,50 @@ describe('MessageList — folder prop (junk)', () => {
   });
 });
 
+describe('MessageList — folder prop (trash)', () => {
+  const TRASH_PROPS = {
+    address: 'hello@example.com',
+    direction: 'inbound' as const,
+    folder: 'trash' as const,
+    initialMessages: INBOUND_MESSAGES,
+    initialNextCursor: null,
+    folderLabel: 'Trash',
+  };
+
+  test('renders Trash folder label', () => {
+    render(<MessageList {...TRASH_PROPS} />);
+    expect(screen.getByText('Trash')).toBeInTheDocument();
+  });
+
+  test('navigates to /trash/[address]/[messageId] on row click', async () => {
+    const { useRouter } = require('next/navigation');
+    const mockPush = jest.fn();
+    useRouter.mockReturnValue({ push: mockPush });
+    const user = userEvent.setup();
+    render(<MessageList {...TRASH_PROPS} />);
+    await user.click(screen.getByTestId('message-row-msg-1'));
+    expect(mockPush).toHaveBeenCalledWith('/trash/hello%40example.com/msg-1');
+  });
+
+  test('passes folder=trash to API on pagination', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [], nextCursor: null }),
+    });
+    const user = userEvent.setup();
+    render(<MessageList {...TRASH_PROPS} initialNextCursor="cursor1" />);
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('folder=trash'));
+    });
+  });
+
+  test('does not subscribe to WebSocket events for trash folder', () => {
+    render(<MessageList {...TRASH_PROPS} />);
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+});
+
 describe('MessageList — card layout', () => {
   test('renders message snippet when provided', () => {
     const msgs = [{ ...INBOUND_MESSAGES[0], snippet: 'This is a preview of the email body' }];

--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -179,6 +179,55 @@ describe('MessageDetail', () => {
   });
 });
 
+describe('MessageDetail — trash folder', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    mockPathname.mockReturnValue('/trash/test%40example.com/msg-1');
+  });
+
+  test('shows Restore to Inbox button when in trash folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.getByRole('button', { name: /restore to inbox/i })).toBeInTheDocument();
+  });
+
+  test('does not show Move to Junk button when in trash folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.queryByRole('button', { name: /move to junk/i })).not.toBeInTheDocument();
+  });
+
+  test('does not show read toggle when in trash folder', () => {
+    render(<MessageDetail message={BASE_MSG} />);
+    expect(screen.queryByRole('button', { name: /mark as (un)?read/i })).not.toBeInTheDocument();
+  });
+
+  test('calls PATCH with folder=inbox on Restore to Inbox click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/messages/msg-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'inbox' }) }),
+      );
+    });
+  });
+
+  test('dispatches hermes:messageremoved after Restore to Inbox from trash', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const events: CustomEvent[] = [];
+    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+    });
+    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  });
+});
+
 describe('MessageDetail — junk folder', () => {
   beforeEach(() => {
     global.fetch = jest.fn();

--- a/app/app/(app)/trash/[address]/[messageId]/page.tsx
+++ b/app/app/(app)/trash/[address]/[messageId]/page.tsx
@@ -1,0 +1,82 @@
+import { cookies } from 'next/headers';
+import { redirect, notFound } from 'next/navigation';
+import { MessageDetail } from '@/components/messages/message-detail';
+
+interface Attachment {
+  filename: string;
+  url: string;
+  contentType?: string;
+  size?: number;
+}
+
+interface Message {
+  messageId: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  cc?: string;
+  subject: string;
+  receivedAt: string;
+  isRead: boolean;
+  bodyHtmlUrl?: string;
+  bodyTextUrl?: string;
+  attachments?: Attachment[];
+}
+
+async function getMessage(id: string): Promise<Message | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('access_token')?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const res = await fetch(`${baseUrl}/api/messages/${encodeURIComponent(id)}`, {
+    headers: { Cookie: `access_token=${token}` },
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login');
+  }
+
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+
+  const data = await res.json();
+  return data.message ?? null;
+}
+
+async function fetchBodyFromS3(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    return res.ok ? res.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+interface Props {
+  params: Promise<{ address: string; messageId: string }>;
+}
+
+export default async function TrashMessageDetailPage({ params }: Props) {
+  const { messageId } = await params;
+  const message = await getMessage(messageId);
+
+  if (!message) {
+    notFound();
+  }
+
+  const htmlBody = message.bodyHtmlUrl ? await fetchBodyFromS3(message.bodyHtmlUrl) : null;
+  const textBody = !htmlBody && message.bodyTextUrl ? await fetchBodyFromS3(message.bodyTextUrl) : null;
+
+  return (
+    <MessageDetail
+      message={message}
+      initialHtmlBody={htmlBody}
+      initialTextBody={textBody}
+    />
+  );
+}

--- a/app/app/(app)/trash/[address]/layout.tsx
+++ b/app/app/(app)/trash/[address]/layout.tsx
@@ -1,0 +1,62 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { MailboxLayout } from '@/components/layout/mailbox-layout';
+import { MessageList } from '@/components/inbox/message-list';
+
+interface Message {
+  messageId: string;
+  address: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  direction?: 'inbound' | 'outbound';
+  subject: string;
+  receivedAt: string;
+  isRead: boolean;
+  attachments?: { filename: string; s3Key: string }[];
+}
+
+async function getMessages(address: string) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('access_token')?.value;
+  if (!token) redirect('/login');
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+  const params = new URLSearchParams({ address, folder: 'trash' });
+  const res = await fetch(`${baseUrl}/api/messages?${params.toString()}`, {
+    headers: { Cookie: `access_token=${token}` },
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) redirect('/login');
+  if (!res.ok) return { messages: [] as Message[], nextCursor: null };
+
+  return res.json() as Promise<{ messages: Message[]; nextCursor: string | null }>;
+}
+
+interface Props {
+  params: Promise<{ address: string }>;
+  children: React.ReactNode;
+}
+
+export default async function TrashAddressLayout({ params, children }: Props) {
+  const { address } = await params;
+  const decodedAddress = decodeURIComponent(address);
+  const { messages, nextCursor } = await getMessages(decodedAddress);
+
+  return (
+    <MailboxLayout
+      list={
+        <MessageList
+          address={decodedAddress}
+          direction="inbound"
+          folder="trash"
+          initialMessages={messages}
+          initialNextCursor={nextCursor}
+          folderLabel="Trash"
+        />
+      }
+      detail={children}
+    />
+  );
+}

--- a/app/app/(app)/trash/[address]/page.tsx
+++ b/app/app/(app)/trash/[address]/page.tsx
@@ -1,12 +1,5 @@
-import { ComingSoonPane } from '@/components/messages/coming-soon-pane';
-import { MailboxLayout } from '@/components/layout/mailbox-layout';
 import { MailboxEmptyState } from '@/components/messages/mailbox-empty-state';
 
 export default function TrashPage() {
-  return (
-    <MailboxLayout
-      list={<ComingSoonPane label="Trash" />}
-      detail={<MailboxEmptyState />}
-    />
-  );
+  return <MailboxEmptyState />;
 }

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -158,7 +158,7 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
 
         <TooltipProvider delayDuration={300}>
           <div className="flex items-center gap-1 shrink-0">
-            {folder === 'junk' ? (
+            {(folder === 'junk' || folder === 'trash') ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button


### PR DESCRIPTION
- Create trash folder layout, page, and message detail route; fetches messages with folder=trash from the API
- Extend MessageDetail to show Restore to Inbox for both junk and trash folders; trash does not show the read toggle per spec
- Add MessageList tests for folder=trash routing and API params
- Add MessageDetail tests for trash folder toolbar and restore action
- All 378 tests passing

closes #169