### PR TITLE
[feat]: implement Move to Junk action (#170)

### DIFF
--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -179,6 +179,50 @@ describe('MessageDetail', () => {
   });
 });
 
+describe('MessageDetail — Move to Junk', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    mockPathname.mockReturnValue('/inbox/test%40example.com/msg-1');
+  });
+
+  test('calls PATCH with folder=junk on Move to Junk click', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /move to junk/i }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/messages/msg-1',
+        expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'junk' }) }),
+      );
+    });
+  });
+
+  test('dispatches hermes:messageremoved after Move to Junk', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
+    const events: CustomEvent[] = [];
+    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /move to junk/i }));
+    await waitFor(() => {
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+    });
+    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  });
+
+  test('calls toast.error when Move to Junk fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /move to junk/i }));
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/failed to move/i));
+    });
+  });
+});
+
 describe('MessageDetail — trash folder', () => {
   beforeEach(() => {
     global.fetch = jest.fn();

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -140,8 +140,24 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
     }
   }
 
-  function handleMoveToJunk() {
-    toast.info('Move to Junk coming soon', { id: 'move-to-junk' });
+  async function handleMoveToJunk() {
+    try {
+      const res = await fetch(`/api/messages/${message.messageId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder: 'junk' }),
+      });
+      if (!res.ok) {
+        toast.error('Failed to move message to Junk');
+        return;
+      }
+      dispatchMessageRemoved(message.messageId);
+      toast.success('Moved to Junk');
+      router.push(listHref);
+      router.refresh();
+    } catch {
+      toast.error('Failed to move message to Junk');
+    }
   }
 
   const currentAddress = message.address ?? (isSent ? message.from : message.to) ?? '';


### PR DESCRIPTION
- Replace coming-soon stub in handleMoveToJunk with a real PATCH request that sets folder=junk on the message
- Dispatch hermes:messageremoved so the message disappears from the inbox list immediately; show success toast and navigate back
- Show toast.error on failure
- Add tests covering the happy path, event dispatch, and error case
- All 381 tests passing

closes #170