### PR TITLE
[fix]: optimistically clear unread badge on email click (#183)

### DIFF
--- a/app/__tests__/components/inbox/message-list.test.tsx
+++ b/app/__tests__/components/inbox/message-list.test.tsx
@@ -325,6 +325,18 @@ describe('MessageList — folder prop (junk)', () => {
     expect(mockSubscribe).not.toHaveBeenCalled();
   });
 
+  test('optimistically clears unread badge when clicking an unread junk message', async () => {
+    const { useRouter } = require('next/navigation');
+    useRouter.mockReturnValue({ push: jest.fn() });
+    const user = userEvent.setup();
+    render(<MessageList {...JUNK_PROPS} />);
+    expect(screen.getByLabelText('Unread')).toBeInTheDocument();
+    await user.click(screen.getByTestId('message-row-msg-2'));
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
+    });
+  });
+
   test('does not dispatch hermes:inboxcount for junk folder', () => {
     const events: CustomEvent[] = [];
     const handler = (e: Event) => events.push(e as CustomEvent);
@@ -459,5 +471,27 @@ describe('MessageList — shared', () => {
     render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
     await user.click(screen.getByTestId('message-row-msg-out'));
     expect(mockPush).toHaveBeenCalledWith('/sent/hello%40example.com/msg-out');
+  });
+
+  test('optimistically clears unread badge when clicking an unread inbox message', async () => {
+    const { useRouter } = require('next/navigation');
+    useRouter.mockReturnValue({ push: jest.fn() });
+    const user = userEvent.setup();
+    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    expect(screen.getByLabelText('Unread')).toBeInTheDocument();
+    await user.click(screen.getByTestId('message-row-msg-2'));
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not optimistically clear unread badge for outbound messages', async () => {
+    const { useRouter } = require('next/navigation');
+    useRouter.mockReturnValue({ push: jest.fn() });
+    const unreadOutbound = [{ ...OUTBOUND_MESSAGES[0], isRead: false }];
+    const user = userEvent.setup();
+    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} initialMessages={unreadOutbound} />);
+    await user.click(screen.getByTestId('message-row-msg-out'));
+    expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
   });
 });

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -127,6 +127,13 @@ export function MessageList({ address, direction, folder, initialMessages, initi
 
   function handleRowClick(msg: Message) {
     const root = folder ?? (direction === 'outbound' ? 'sent' : 'inbox');
+    // Optimistically mark as read so the blue dot clears immediately on click,
+    // without waiting for the async PATCH in MessageDetail.
+    if (!isSent && !msg.isRead && (folder === 'inbox' || folder === 'junk' || !folder)) {
+      setMessages((prev) =>
+        prev.map((m) => m.messageId === msg.messageId ? { ...m, isRead: true } : m),
+      );
+    }
     router.push(`/${root}/${encodeURIComponent(address)}/${msg.messageId}`);
   }
 


### PR DESCRIPTION
Mark a message as read in MessageList state immediately when the user clicks a row, before the async PATCH in MessageDetail completes.

Previously the UI relied on a hermes:readstatus custom event fired after a successful PATCH. In the Next.js App Router three-pane layout the server re-renders the layout (and may remount MessageList) during navigation, creating a race where the event could be dispatched before the new event listener was established, leaving the blue dot stuck.

Optimistic update eliminates the race: the state change is synchronous on the same tick as the click, so the dot always clears instantly.

closes #183