### PR TITLE
[feat]: add immediate visual feedback on all interactive elements (#185)

### DIFF
--- a/app/components/drafts/drafts-list.tsx
+++ b/app/components/drafts/drafts-list.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { FileText } from 'lucide-react';
 import { MailboxCard, formatMailboxDate } from '@/components/mailbox-card';
@@ -25,21 +26,30 @@ interface DraftsListProps {
 export function DraftsList({ drafts }: DraftsListProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const [pendingDraftId, setPendingDraftId] = useState<string | null>(null);
 
   const activeDraftId = (() => {
     const segments = pathname.split('/');
     return segments.length >= 4 ? segments[3] : null;
   })();
 
+  useEffect(() => {
+    setPendingDraftId(null);
+  }, [pathname]);
+
   function handleDraftClick(draft: Draft) {
     if (draft.inReplyToMessageId) {
       const address = encodeURIComponent(draft.from ?? '');
       const inReplyTo = draft.inReplyToMessageId;
-      tryNavigate(() => router.push(
-        `/inbox/${address}/${encodeURIComponent(inReplyTo)}?draftId=${draft.draftId}&mode=reply`,
-      ));
+      tryNavigate(() => {
+        setPendingDraftId(draft.draftId);
+        router.push(`/inbox/${address}/${encodeURIComponent(inReplyTo)}?draftId=${draft.draftId}&mode=reply`);
+      });
     } else {
-      tryNavigate(() => router.push(`/drafts/${encodeURIComponent(draft.from ?? '')}/${draft.draftId}`));
+      tryNavigate(() => {
+        setPendingDraftId(draft.draftId);
+        router.push(`/drafts/${encodeURIComponent(draft.from ?? '')}/${draft.draftId}`);
+      });
     }
   }
 
@@ -61,7 +71,8 @@ export function DraftsList({ drafts }: DraftsListProps) {
         <MailboxCard
           key={draft.draftId}
           testId={`draft-row-${draft.draftId}`}
-          isActive={draft.draftId === activeDraftId}
+          isActive={draft.draftId === activeDraftId || draft.draftId === pendingDraftId}
+          isLoading={draft.draftId === pendingDraftId}
           displayName={draft.to?.trim() || 'No recipient'}
           date={formatMailboxDate(draft.updatedAt)}
           subject={draft.subject?.trim() || '(no subject)'}

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -45,6 +45,7 @@ export function MessageList({ address, direction, folder, initialMessages, initi
   const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
   const [filter, setFilter] = useState<Filter>('all');
   const [isLoading, setIsLoading] = useState(false);
+  const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
 
   const isInboxFolder = folder === 'inbox' || (!folder && direction === 'inbound');
 
@@ -52,6 +53,11 @@ export function MessageList({ address, direction, folder, initialMessages, initi
     const segments = pathname.split('/');
     return segments.length >= 4 ? segments[3] : null;
   })();
+
+  // Clear pending state once the navigation lands
+  useEffect(() => {
+    setPendingMessageId(null);
+  }, [pathname]);
 
   useEffect(() => {
     if (!isInboxFolder) return;
@@ -126,6 +132,7 @@ export function MessageList({ address, direction, folder, initialMessages, initi
   }, [address, direction, folder]);
 
   function handleRowClick(msg: Message) {
+    setPendingMessageId(msg.messageId);
     const root = folder ?? (direction === 'outbound' ? 'sent' : 'inbox');
     // Optimistically mark as read so the blue dot clears immediately on click,
     // without waiting for the async PATCH in MessageDetail.
@@ -196,7 +203,7 @@ export function MessageList({ address, direction, folder, initialMessages, initi
           <>
             <div className="flex flex-col gap-2 p-2">
               {displayed.map((msg) => {
-                const isActive = msg.messageId === activeMessageId;
+                const isActive = msg.messageId === activeMessageId || msg.messageId === pendingMessageId;
                 const isUnread = !isSent && !msg.isRead;
                 const displayName = isSent
                   ? extractDisplayName(msg.to ?? '')
@@ -207,6 +214,7 @@ export function MessageList({ address, direction, folder, initialMessages, initi
                     key={msg.messageId}
                     testId={`message-row-${msg.messageId}`}
                     isActive={isActive}
+                    isLoading={msg.messageId === pendingMessageId}
                     isUnread={isUnread}
                     displayName={displayName}
                     date={formatMailboxDate(msg.receivedAt)}

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -82,10 +82,13 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
 
   const isOnDraftDetailRoute = /^\/drafts\/[^/]+\/[^/]+$/.test(pathname);
   const [isComposing, setIsComposing] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const [switchingToAddress, setSwitchingToAddress] = useState<string | null>(null);
 
-  // Reset loading state once navigation lands on any new page
+  // Reset loading states once navigation lands on any new page
   useEffect(() => {
     setIsComposing(false);
+    setSwitchingToAddress(null);
   }, [pathname]);
 
   const [unreadCounts, setUnreadCounts] = useState<Map<string, number>>(() => {
@@ -161,13 +164,19 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
   }
 
   async function handleSignOut() {
-    await fetch("/api/auth/signout", { method: "POST" });
-    router.push("/login");
+    setIsSigningOut(true);
+    try {
+      await fetch("/api/auth/signout", { method: "POST" });
+      router.push("/login");
+    } catch {
+      setIsSigningOut(false);
+    }
   }
 
   function handleAddressSwitch(email: string) {
     const folder = FOLDERS.find((f) => pathname.startsWith(`/${f.key}/`));
     const target = folder ? folder.href(email) : `/inbox/${encodeURIComponent(email)}`;
+    setSwitchingToAddress(email);
     tryNavigate(() => router.push(target));
   }
 
@@ -211,8 +220,13 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
                     <DropdownMenuItem
                       key={addr.email}
                       onSelect={() => handleAddressSwitch(addr.email)}
+                      disabled={switchingToAddress !== null}
                       className={cn(addr.email === selectedAddress && "font-medium")}
                     >
+                      {switchingToAddress === addr.email
+                        ? <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                        : <Mail className="h-4 w-4 shrink-0 opacity-0" />
+                      }
                       {addr.email}
                     </DropdownMenuItem>
                   ))}
@@ -297,8 +311,8 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Sign out" onClick={handleSignOut}>
-              <LogOut />
+            <SidebarMenuButton tooltip="Sign out" onClick={handleSignOut} disabled={isSigningOut} aria-busy={isSigningOut}>
+              {isSigningOut ? <Loader2 className="animate-spin" /> : <LogOut />}
               <span>Sign out</span>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/app/components/mailbox-card.tsx
+++ b/app/components/mailbox-card.tsx
@@ -1,10 +1,11 @@
 import { Badge } from '@/components/ui/badge';
-import { Paperclip } from 'lucide-react';
+import { Loader2, Paperclip } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface MailboxCardProps {
   testId: string;
   isActive: boolean;
+  isLoading?: boolean;
   isUnread?: boolean;
   displayName: string;
   date: string;
@@ -17,6 +18,7 @@ export interface MailboxCardProps {
 export function MailboxCard({
   testId,
   isActive,
+  isLoading = false,
   isUnread = false,
   displayName,
   date,
@@ -52,7 +54,10 @@ export function MailboxCard({
           </span>
         </div>
         <div className="flex items-center gap-1 shrink-0 text-xs text-muted-foreground">
-          {hasAttachments && <Paperclip className="h-3 w-3" />}
+          {isLoading
+            ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            : hasAttachments && <Paperclip className="h-3 w-3" />
+          }
           <span>{date}</span>
         </div>
       </div>

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -15,6 +15,7 @@ import {
   MailOpen,
   Download,
   Inbox,
+  Loader2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ReplyComposer } from '@/components/messages/reply-composer';
@@ -64,6 +65,9 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   const [isRead, setIsRead] = useState(message.isRead);
   const [composerMode, setComposerMode] = useState<ComposerMode>(initialComposerMode ?? null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const [isMovingToJunk, setIsMovingToJunk] = useState(false);
+  const [isTogglingRead, setIsTogglingRead] = useState(false);
 
   function dispatchReadEvent(messageId: string, isRead: boolean) {
     window.dispatchEvent(new CustomEvent('hermes:readstatus', { detail: { messageId, isRead } }));
@@ -86,6 +90,7 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   async function toggleRead() {
     const next = !isRead;
     setIsRead(next);
+    setIsTogglingRead(true);
     try {
       await fetch(`/api/messages/${message.messageId}`, {
         method: 'PATCH',
@@ -95,6 +100,8 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
       dispatchReadEvent(message.messageId, next);
     } catch {
       setIsRead(!next);
+    } finally {
+      setIsTogglingRead(false);
     }
   }
 
@@ -144,6 +151,7 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   }
 
   async function handleRestoreToInbox() {
+    setIsRestoring(true);
     try {
       const res = await fetch(`/api/messages/${message.messageId}`, {
         method: 'PATCH',
@@ -160,10 +168,13 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
       router.refresh();
     } catch {
       toast.error('Failed to restore message');
+    } finally {
+      setIsRestoring(false);
     }
   }
 
   async function handleMoveToJunk() {
+    setIsMovingToJunk(true);
     try {
       const res = await fetch(`/api/messages/${message.messageId}`, {
         method: 'PATCH',
@@ -180,6 +191,8 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
       router.refresh();
     } catch {
       toast.error('Failed to move message to Junk');
+    } finally {
+      setIsMovingToJunk(false);
     }
   }
 
@@ -205,9 +218,10 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
                     variant="ghost"
                     className="h-8 w-8"
                     onClick={handleRestoreToInbox}
+                    disabled={isRestoring}
                     aria-label="Restore to Inbox"
                   >
-                    <Inbox className="h-4 w-4" />
+                    {isRestoring ? <Loader2 className="h-4 w-4 animate-spin" /> : <Inbox className="h-4 w-4" />}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Restore to Inbox</TooltipContent>
@@ -220,9 +234,10 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
                     variant="ghost"
                     className="h-8 w-8"
                     onClick={handleMoveToJunk}
+                    disabled={isMovingToJunk}
                     aria-label="Move to Junk"
                   >
-                    <AlertTriangle className="h-4 w-4" />
+                    {isMovingToJunk ? <Loader2 className="h-4 w-4 animate-spin" /> : <AlertTriangle className="h-4 w-4" />}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Move to Junk</TooltipContent>
@@ -302,9 +317,10 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
                       variant="ghost"
                       className="h-8 w-8"
                       onClick={toggleRead}
+                      disabled={isTogglingRead}
                       aria-label={isRead ? 'Mark as Unread' : 'Mark as Read'}
                     >
-                      <MailOpen className="h-4 w-4" />
+                      {isTogglingRead ? <Loader2 className="h-4 w-4 animate-spin" /> : <MailOpen className="h-4 w-4" />}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>{isRead ? 'Mark as Unread' : 'Mark as Read'}</TooltipContent>

--- a/app/components/settings/settings-view.tsx
+++ b/app/components/settings/settings-view.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { Loader2 } from 'lucide-react';
 import {
   Table,
   TableBody,
@@ -48,10 +50,16 @@ function addressStatusLabel(status: string): string {
 
 export function SettingsView({ domains, addresses }: SettingsViewProps) {
   const router = useRouter();
+  const [isSigningOut, setIsSigningOut] = useState(false);
 
   async function handleSignOut() {
-    await fetch('/api/auth/signout', { method: 'POST' });
-    router.push('/login');
+    setIsSigningOut(true);
+    try {
+      await fetch('/api/auth/signout', { method: 'POST' });
+      router.push('/login');
+    } catch {
+      setIsSigningOut(false);
+    }
   }
 
   return (
@@ -135,8 +143,10 @@ export function SettingsView({ domains, addresses }: SettingsViewProps) {
         <Button
           variant="destructive"
           onClick={handleSignOut}
+          disabled={isSigningOut}
           data-testid="sign-out-button"
         >
+          {isSigningOut && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Sign out
         </Button>
       </div>


### PR DESCRIPTION
- Message list rows (inbox/sent/junk/trash/drafts) now highlight instantly on click via pendingMessageId/pendingDraftId state, with a spinner on the card while the route loads
- Restore to Inbox, Move to Junk, and Toggle Read/Unread toolbar buttons show a spinner and disable during in-flight PATCH requests
- Sign out button (sidebar and settings) disables with spinner during POST + navigate; resets on error
- Address switcher disables all items and shows a spinner on the selected row during navigation

closes #185