### PR TITLE
[fix]: remove redundant status field from messages (#188)

### DIFF
--- a/app/__tests__/app/api/messages/[id]/route.test.ts
+++ b/app/__tests__/app/api/messages/[id]/route.test.ts
@@ -69,7 +69,6 @@ const EXISTING_ITEM = {
   address: 'inbox@example.com',
   subject: 'Hello',
   isRead: false,
-  status: 'unread',
 };
 
 // ── GET /api/messages/:id ────────────────────────────────────────────────────
@@ -271,26 +270,26 @@ describe('PATCH /api/messages/:id', () => {
 
   test('marks message as read and returns updated item', async () => {
     mockDynamoSend.mockResolvedValueOnce({ Item: EXISTING_ITEM });
-    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: true, status: 'read' } });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: true } });
 
     const res = await PATCH(makePatchReq('msg-1', { isRead: true }), makeParams('msg-1'));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.message.isRead).toBe(true);
-    expect(body.message.status).toBe('read');
+    expect(body.message.status).toBeUndefined();
   });
 
   test('marks message as unread and returns updated item', async () => {
-    mockDynamoSend.mockResolvedValueOnce({ Item: { ...EXISTING_ITEM, isRead: true, status: 'read' } });
-    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: false, status: 'unread' } });
+    mockDynamoSend.mockResolvedValueOnce({ Item: { ...EXISTING_ITEM, isRead: true } });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: false } });
 
     const res = await PATCH(makePatchReq('msg-1', { isRead: false }), makeParams('msg-1'));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.message.isRead).toBe(false);
-    expect(body.message.status).toBe('unread');
+    expect(body.message.status).toBeUndefined();
   });
 
   test('writes correct UpdateExpression to DynamoDB', async () => {
@@ -305,8 +304,9 @@ describe('PATCH /api/messages/:id', () => {
     expect(updateCall).toMatchObject({
       TableName: 'hermes-messages',
       Key: { messageId: 'msg-1' },
-      ExpressionAttributeValues: expect.objectContaining({ ':isRead': true, ':status': 'read' }),
+      ExpressionAttributeValues: expect.objectContaining({ ':isRead': true }),
     });
+    expect((updateCall?.ExpressionAttributeValues as Record<string, unknown>)[':status']).toBeUndefined();
   });
 
   test('returns 404 for non-existent message', async () => {

--- a/app/app/api/messages/[id]/route.ts
+++ b/app/app/api/messages/[id]/route.ts
@@ -129,10 +129,8 @@ export async function PATCH(
   const expressionAttributeValues: Record<string, unknown> = { ':now': new Date().toISOString() };
 
   if (hasIsRead) {
-    setClauses.push('isRead = :isRead', '#status = :status');
-    expressionAttributeNames['#status'] = 'status';
+    setClauses.push('isRead = :isRead');
     expressionAttributeValues[':isRead'] = isRead;
-    expressionAttributeValues[':status'] = isRead ? 'read' : 'unread';
   }
 
   if (hasFolder) {

--- a/app/app/api/messages/route.ts
+++ b/app/app/api/messages/route.ts
@@ -216,7 +216,6 @@ export async function POST(req: NextRequest) {
       ...(bcc ? { bcc: bcc as string } : {}),
       subject: subject as string,
       receivedAt: sentAt,
-      status: 'sent',
       isRead: true,
       bodyTextS3Key: bodyS3Key,
       snippet: (emailBody as string).replace(/\s+/g, ' ').trim().slice(0, 300) || undefined,


### PR DESCRIPTION
isRead (boolean) is the single source of truth for read state. The status mirror written by the PATCH handler was never read by the frontend and created a semantically overloaded field (status: sent on outbound vs status: read/unread on inbound). Removed both.

closes #188