### PR TITLE
[fix]: remove stale status assertion from messages route test

### DIFF
--- a/app/__tests__/app/api/messages/route.test.ts
+++ b/app/__tests__/app/api/messages/route.test.ts
@@ -368,7 +368,6 @@ describe('POST /api/messages', () => {
     expect(item.to).toBe('recipient@example.com');
     expect(item.subject).toBe('Hello');
     expect(item.isRead).toBe(true);
-    expect(item.status).toBe('sent');
     expect(item.address).toBe('me@hermes.com');
   });
 


### PR DESCRIPTION
PR #191 removed status: sent from the DynamoDB write in POST /api/messages but the test still asserted item.status === sent. isRead is the single source of truth for read state per the #188 fix.

closes #192