### PR TITLE
[feat]: auto-expire junk and trash messages after 30 days (#187)

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -35,6 +35,7 @@ jobs:
             infra/package-lock.json
             infra/lambda/inbound-email-processor/package-lock.json
             infra/lambda/ws-connect/package-lock.json
+            infra/lambda/cleanup-expired-messages/package-lock.json
 
       - name: Install app dependencies
         working-directory: app
@@ -54,6 +55,10 @@ jobs:
 
       - name: Install ws-connect dependencies
         working-directory: infra/lambda/ws-connect
+        run: npm ci
+
+      - name: Install cleanup-expired-messages dependencies
+        working-directory: infra/lambda/cleanup-expired-messages
         run: npm ci
 
       - name: Run infra tests
@@ -79,6 +84,7 @@ jobs:
             infra/package-lock.json
             infra/lambda/inbound-email-processor/package-lock.json
             infra/lambda/ws-connect/package-lock.json
+            infra/lambda/cleanup-expired-messages/package-lock.json
 
       - name: Configure AWS credentials (OIDC)
         id: aws-creds
@@ -98,6 +104,10 @@ jobs:
 
       - name: Install ws-connect dependencies
         working-directory: infra/lambda/ws-connect
+        run: npm ci
+
+      - name: Install cleanup-expired-messages dependencies
+        working-directory: infra/lambda/cleanup-expired-messages
         run: npm ci
 
       - name: CDK diff
@@ -155,6 +165,7 @@ jobs:
             infra/package-lock.json
             infra/lambda/inbound-email-processor/package-lock.json
             infra/lambda/ws-connect/package-lock.json
+            infra/lambda/cleanup-expired-messages/package-lock.json
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -172,6 +183,10 @@ jobs:
 
       - name: Install ws-connect dependencies
         working-directory: infra/lambda/ws-connect
+        run: npm ci
+
+      - name: Install cleanup-expired-messages dependencies
+        working-directory: infra/lambda/cleanup-expired-messages
         run: npm ci
 
       - name: Detect changed paths

--- a/app/__tests__/app/api/messages/[id]/route.test.ts
+++ b/app/__tests__/app/api/messages/[id]/route.test.ts
@@ -402,4 +402,44 @@ describe('PATCH /api/messages/:id', () => {
 
     expect(mockDynamoSend).not.toHaveBeenCalled();
   });
+
+  test('writes folderMovedAt when folder changes', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: { ...EXISTING_ITEM, folder: 'inbox' } });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, folder: 'junk' } });
+
+    await PATCH(makePatchReq('msg-1', { folder: 'junk' }), makeParams('msg-1'));
+
+    const updateCall = (mockDynamoSend.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([cmd]) => 'UpdateExpression' in cmd,
+    )?.[0];
+    const values = updateCall?.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[':folderMovedAt']).toBeDefined();
+    expect(typeof values[':folderMovedAt']).toBe('string');
+  });
+
+  test('does not write folderMovedAt when only isRead changes', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: EXISTING_ITEM });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, isRead: true } });
+
+    await PATCH(makePatchReq('msg-1', { isRead: true }), makeParams('msg-1'));
+
+    const updateCall = (mockDynamoSend.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([cmd]) => 'UpdateExpression' in cmd,
+    )?.[0];
+    const values = updateCall?.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[':folderMovedAt']).toBeUndefined();
+  });
+
+  test('does not write folderMovedAt when folder is set to the same value', async () => {
+    mockDynamoSend.mockResolvedValueOnce({ Item: { ...EXISTING_ITEM, folder: 'junk' } });
+    mockDynamoSend.mockResolvedValueOnce({ Attributes: { ...EXISTING_ITEM, folder: 'junk' } });
+
+    await PATCH(makePatchReq('msg-1', { folder: 'junk' }), makeParams('msg-1'));
+
+    const updateCall = (mockDynamoSend.mock.calls as Array<[Record<string, unknown>]>).find(
+      ([cmd]) => 'UpdateExpression' in cmd,
+    )?.[0];
+    const values = updateCall?.ExpressionAttributeValues as Record<string, unknown>;
+    expect(values[':folderMovedAt']).toBeUndefined();
+  });
 });

--- a/app/app/api/messages/[id]/route.ts
+++ b/app/app/api/messages/[id]/route.ts
@@ -134,9 +134,14 @@ export async function PATCH(
   }
 
   if (hasFolder) {
+    const currentFolder = existing.Item?.folder;
     setClauses.push('#folder = :folder');
     expressionAttributeNames['#folder'] = 'folder';
     expressionAttributeValues[':folder'] = folder;
+    if (folder !== currentFolder) {
+      setClauses.push('folderMovedAt = :folderMovedAt');
+      expressionAttributeValues[':folderMovedAt'] = new Date().toISOString();
+    }
   }
 
   const result = await dynamo.send(new UpdateCommand({

--- a/infra/lambda/cleanup-expired-messages/index.js
+++ b/infra/lambda/cleanup-expired-messages/index.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const { S3Client, DeleteObjectCommand } = require('@aws-sdk/client-s3');
+const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocumentClient, ScanCommand, UpdateCommand, DeleteCommand } = require('@aws-sdk/lib-dynamodb');
+
+const MESSAGES_TABLE = process.env.MESSAGES_TABLE;
+const S3_BUCKET = process.env.S3_BUCKET;
+const EXPIRY_DAYS = 30;
+
+function getClients() {
+  const s3 = new S3Client({});
+  const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  return { s3, dynamo };
+}
+
+function cutoff() {
+  const d = new Date();
+  d.setDate(d.getDate() - EXPIRY_DAYS);
+  return d.toISOString();
+}
+
+async function deleteS3Keys(s3, keys) {
+  await Promise.all(
+    keys.filter(Boolean).map((key) =>
+      s3.send(new DeleteObjectCommand({ Bucket: S3_BUCKET, Key: key })),
+    ),
+  );
+}
+
+exports.handler = async () => {
+  const { s3, dynamo } = getClients();
+  const threshold = cutoff();
+
+  let junkMoved = 0;
+  let trashDeleted = 0;
+
+  // Scan all messages once; partition by folder
+  let lastKey;
+  const junkExpired = [];
+  const trashExpired = [];
+
+  do {
+    const result = await dynamo.send(new ScanCommand({
+      TableName: MESSAGES_TABLE,
+      ExclusiveStartKey: lastKey,
+      FilterExpression: '#f IN (:junk, :trash)',
+      ExpressionAttributeNames: { '#f': 'folder' },
+      ExpressionAttributeValues: { ':junk': 'junk', ':trash': 'trash' },
+      ProjectionExpression: 'messageId, #f, folderMovedAt, bodyTextS3Key, bodyHtmlS3Key, attachments',
+    }));
+
+    for (const item of result.Items ?? []) {
+      const movedAt = item.folderMovedAt;
+      if (!movedAt || movedAt > threshold) continue;
+
+      if (item.folder === 'junk') junkExpired.push(item);
+      else if (item.folder === 'trash') trashExpired.push(item);
+    }
+
+    lastKey = result.LastEvaluatedKey;
+  } while (lastKey);
+
+  // Junk → Trash
+  await Promise.all(junkExpired.map(async (item) => {
+    const now = new Date().toISOString();
+    await dynamo.send(new UpdateCommand({
+      TableName: MESSAGES_TABLE,
+      Key: { messageId: item.messageId },
+      UpdateExpression: 'SET #f = :trash, folderMovedAt = :now, updatedAt = :now',
+      ExpressionAttributeNames: { '#f': 'folder' },
+      ExpressionAttributeValues: { ':trash': 'trash', ':now': now },
+    }));
+    junkMoved++;
+  }));
+
+  // Trash → Delete (DynamoDB + S3)
+  await Promise.all(trashExpired.map(async (item) => {
+    await dynamo.send(new DeleteCommand({
+      TableName: MESSAGES_TABLE,
+      Key: { messageId: item.messageId },
+    }));
+
+    const s3Keys = [
+      item.bodyTextS3Key,
+      item.bodyHtmlS3Key,
+      ...(Array.isArray(item.attachments) ? item.attachments : []),
+    ];
+    await deleteS3Keys(s3, s3Keys);
+    trashDeleted++;
+  }));
+
+  console.log(JSON.stringify({ junkMoved, trashDeleted }));
+  return { junkMoved, trashDeleted };
+};

--- a/infra/lambda/cleanup-expired-messages/package-lock.json
+++ b/infra/lambda/cleanup-expired-messages/package-lock.json
@@ -1,0 +1,850 @@
+{
+  "name": "cleanup-expired-messages",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cleanup-expired-messages",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/client-s3": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1057.0.tgz",
+      "integrity": "sha512-S0feh4mSWsqxQ8SGWIqAX5CQ9w+wBFxpNx4QVNy4rfQVMY6PvPuWT6kolfIHqMoIvuVGd9zD71BvzCK3CHip8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/dynamodb-codec": "^3.973.15",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1057.0.tgz",
+      "integrity": "sha512-4MV5+ph7WSLEqStKYdWf2EIHIvLpPzV8xN98jWSVJfUpp5j7T8dyN3AROPPsKWvCme8hbx1ybCjtK76ALCZUYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.17",
+        "@aws-sdk/middleware-expect-continue": "^3.972.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.23",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.44",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
+      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
+      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
+      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
+      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
+      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.47.tgz",
+      "integrity": "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
+      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
+      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
+      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.15.tgz",
+      "integrity": "sha512-R09IUytTrUKwsIiMVSHPZJz0zO9EsXHg/JZ+3AwQ+eSahRnHuPuZANMfeTb/j2+AKkZ7DhW2FcT6XuHLwC0cZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
+      "integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1057.0.tgz",
+      "integrity": "sha512-kufJ2SGaorWaLvrJ9UaLuyjE9UKwxrXbQ2jHqjHWBCHelwSHhlAKXKWN7+Vz53JpUcM604aVI2mJ+1J5YY2xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1057.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
+      "integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.15.tgz",
+      "integrity": "sha512-L1wbvrAb0hv7Vx6eTEyqQwXaNETSj/L30BVCkSxD0k6Ve5cZUM0SLUvBn8aA/B4YtIpMzCbzNaVytZY7uOzJSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.5",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
+      "integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
+      "integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
+      "integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
+      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
+      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
+      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
+      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1003.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.2",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.6.tgz",
+      "integrity": "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
+      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
+      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
+      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    }
+  }
+}

--- a/infra/lambda/cleanup-expired-messages/package.json
+++ b/infra/lambda/cleanup-expired-messages/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cleanup-expired-messages",
+  "version": "1.0.0",
+  "description": "Hermes cleanup Lambda — moves expired junk to trash and deletes expired trash",
+  "main": "index.js",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0"
+  }
+}

--- a/infra/lib/hermes-email-stack.ts
+++ b/infra/lib/hermes-email-stack.ts
@@ -27,6 +27,7 @@ export class HermesEmailStack extends cdk.Stack {
   public readonly receiptRuleSet: ses.CfnReceiptRuleSet;
   public readonly sesS3DeliveryRole: iam.Role;
   public readonly inboundEmailProcessor: lambda.Function;
+  public readonly cleanupExpiredMessages: lambda.Function;
 
   constructor(scope: Construct, id: string, props: HermesEmailStackProps) {
     super(scope, id, props);
@@ -141,6 +142,59 @@ export class HermesEmailStack extends cdk.Stack {
         },
       },
       targets: [new eventTargets.LambdaFunction(this.inboundEmailProcessor)],
+    });
+
+    const cleanupLogGroup = new logs.LogGroup(this, 'CleanupExpiredMessagesLogGroup', {
+      logGroupName: '/aws/lambda/hermes-cleanup-expired-messages',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const cleanupLambdaDir = path.join(__dirname, '../lambda/cleanup-expired-messages');
+    this.cleanupExpiredMessages = new lambda.Function(this, 'CleanupExpiredMessages', {
+      functionName: 'hermes-cleanup-expired-messages',
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(cleanupLambdaDir, {
+        bundling: {
+          local: {
+            tryBundle(outputDir: string): boolean {
+              try {
+                execSync(
+                  `cp "${cleanupLambdaDir}/index.js" "${cleanupLambdaDir}/package.json" "${cleanupLambdaDir}/package-lock.json" "${outputDir}/"`,
+                  { stdio: 'pipe' },
+                );
+                execSync('npm ci --production', { cwd: outputDir, stdio: 'pipe' });
+                return true;
+              } catch {
+                return false;
+              }
+            },
+          },
+          image: lambda.Runtime.NODEJS_22_X.bundlingImage,
+          command: [
+            'bash',
+            '-c',
+            'cp /asset-input/index.js /asset-input/package.json /asset-input/package-lock.json /asset-output/ && cd /asset-output && npm ci --production',
+          ],
+        },
+      }),
+      logGroup: cleanupLogGroup,
+      timeout: cdk.Duration.minutes(5),
+      environment: {
+        MESSAGES_TABLE: props.messagesTable.tableName,
+        S3_BUCKET: props.emailBucket.bucketName,
+      },
+    });
+    cdk.Tags.of(this.cleanupExpiredMessages).add(HERMES_TAG.key, HERMES_TAG.value);
+
+    props.messagesTable.grantReadWriteData(this.cleanupExpiredMessages);
+    props.emailBucket.grantDelete(this.cleanupExpiredMessages);
+
+    new events.Rule(this, 'CleanupExpiredMessagesRule', {
+      ruleName: 'hermes-cleanup-expired-messages-rule',
+      description: 'Triggers CleanupExpiredMessages daily to expire junk and trash messages',
+      schedule: events.Schedule.cron({ minute: '0', hour: '3' }),
+      targets: [new eventTargets.LambdaFunction(this.cleanupExpiredMessages)],
     });
   }
 }

--- a/infra/test/hermes-email-stack.test.ts
+++ b/infra/test/hermes-email-stack.test.ts
@@ -154,6 +154,35 @@ describe('HermesEmailStack', () => {
     });
   });
 
+  describe('CleanupExpiredMessages Lambda', () => {
+    test('creates CleanupExpiredMessages with Node.js 22.x runtime', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-cleanup-expired-messages',
+        Runtime: 'nodejs22.x',
+        Handler: 'index.handler',
+      });
+    });
+
+    test('CleanupExpiredMessages has required environment variables', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        FunctionName: 'hermes-cleanup-expired-messages',
+        Environment: {
+          Variables: Match.objectLike({
+            MESSAGES_TABLE: 'hermes-messages',
+            S3_BUCKET: 'hermes-email-store',
+          }),
+        },
+      });
+    });
+
+    test('daily EventBridge rule triggers CleanupExpiredMessages at 03:00 UTC', () => {
+      template.hasResourceProperties('AWS::Events::Rule', {
+        Name: 'hermes-cleanup-expired-messages-rule',
+        ScheduleExpression: 'cron(0 3 * * ? *)',
+      });
+    });
+  });
+
   describe('CloudWatch Log Groups', () => {
     test('all log groups have DeletionPolicy Delete', () => {
       const resources = template.toJSON().Resources;
@@ -167,6 +196,12 @@ describe('HermesEmailStack', () => {
     test('creates explicit log group for hermes-inbound-email-processor', () => {
       template.hasResourceProperties('AWS::Logs::LogGroup', {
         LogGroupName: '/aws/lambda/hermes-inbound-email-processor',
+      });
+    });
+
+    test('creates explicit log group for hermes-cleanup-expired-messages', () => {
+      template.hasResourceProperties('AWS::Logs::LogGroup', {
+        LogGroupName: '/aws/lambda/hermes-cleanup-expired-messages',
       });
     });
   });

--- a/infra/test/lambda/cleanup-expired-messages.test.ts
+++ b/infra/test/lambda/cleanup-expired-messages.test.ts
@@ -1,0 +1,250 @@
+const mockS3 = { send: jest.fn() };
+const mockDynamo = { send: jest.fn() };
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(),
+  DeleteObjectCommand: jest.fn((p: unknown) => p),
+}));
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn() },
+  ScanCommand: jest.fn((p: unknown) => p),
+  UpdateCommand: jest.fn((p: unknown) => p),
+  DeleteCommand: jest.fn((p: unknown) => p),
+}));
+
+import { S3Client } from '@aws-sdk/client-s3';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+process.env.MESSAGES_TABLE = 'hermes-messages';
+process.env.S3_BUCKET = 'hermes-email-store';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handler } = require('../../lambda/cleanup-expired-messages/index');
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (S3Client as jest.Mock).mockReturnValue(mockS3);
+  (DynamoDBClient as jest.Mock).mockReturnValue({});
+  (DynamoDBDocumentClient.from as unknown as jest.Mock).mockReturnValue(mockDynamo);
+});
+
+describe('CleanupExpiredMessages', () => {
+  describe('junk messages older than 30 days', () => {
+    const junkItem = {
+      messageId: 'junk-old',
+      folder: 'junk',
+      folderMovedAt: daysAgo(31),
+    };
+
+    beforeEach(() => {
+      mockDynamo.send
+        .mockResolvedValueOnce({ Items: [junkItem] }) // ScanCommand
+        .mockResolvedValue({});                        // UpdateCommand
+    });
+
+    test('moves junk message to trash via UpdateCommand', async () => {
+      await handler();
+      const updateCall = (mockDynamo.send.mock.calls as Array<[Record<string, unknown>]>).find(
+        ([cmd]) => cmd.Key && (cmd.Key as Record<string, unknown>).messageId === 'junk-old' && cmd.UpdateExpression,
+      );
+      expect(updateCall).toBeDefined();
+      expect((updateCall![0].ExpressionAttributeValues as Record<string, unknown>)[':trash']).toBe('trash');
+    });
+
+    test('does not delete the junk message from DynamoDB', async () => {
+      await handler();
+      const deleteCalls = (mockDynamo.send.mock.calls as Array<[Record<string, unknown>]>).filter(
+        ([cmd]) => cmd.Key && (cmd.Key as Record<string, unknown>).messageId === 'junk-old' && !cmd.UpdateExpression,
+      );
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    test('does not delete any S3 objects for junk move', async () => {
+      await handler();
+      expect(mockS3.send).not.toHaveBeenCalled();
+    });
+
+    test('returns junkMoved: 1 and trashDeleted: 0', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 1, trashDeleted: 0 });
+    });
+  });
+
+  describe('junk messages newer than 30 days', () => {
+    const recentJunk = {
+      messageId: 'junk-recent',
+      folder: 'junk',
+      folderMovedAt: daysAgo(10),
+    };
+
+    beforeEach(() => {
+      mockDynamo.send.mockResolvedValueOnce({ Items: [recentJunk] });
+    });
+
+    test('does not touch recent junk messages', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 0 });
+      expect(mockDynamo.send).toHaveBeenCalledTimes(1); // only the scan
+    });
+  });
+
+  describe('trash messages older than 30 days', () => {
+    const trashItem = {
+      messageId: 'trash-old',
+      folder: 'trash',
+      folderMovedAt: daysAgo(31),
+      bodyTextS3Key: 'parsed/trash-old/body.txt',
+      bodyHtmlS3Key: 'parsed/trash-old/body.html',
+      attachments: ['attachments/trash-old/file.pdf'],
+    };
+
+    beforeEach(() => {
+      mockDynamo.send
+        .mockResolvedValueOnce({ Items: [trashItem] }) // ScanCommand
+        .mockResolvedValue({});                         // DeleteCommand
+      mockS3.send.mockResolvedValue({});
+    });
+
+    test('deletes the trash message from DynamoDB', async () => {
+      await handler();
+      const deleteCall = (mockDynamo.send.mock.calls as Array<[Record<string, unknown>]>).find(
+        ([cmd]) => cmd.Key && (cmd.Key as Record<string, unknown>).messageId === 'trash-old' && !cmd.UpdateExpression,
+      );
+      expect(deleteCall).toBeDefined();
+    });
+
+    test('deletes bodyTextS3Key from S3', async () => {
+      await handler();
+      expect(mockS3.send).toHaveBeenCalledWith(
+        expect.objectContaining({ Bucket: 'hermes-email-store', Key: 'parsed/trash-old/body.txt' }),
+      );
+    });
+
+    test('deletes bodyHtmlS3Key from S3', async () => {
+      await handler();
+      expect(mockS3.send).toHaveBeenCalledWith(
+        expect.objectContaining({ Key: 'parsed/trash-old/body.html' }),
+      );
+    });
+
+    test('deletes attachment from S3', async () => {
+      await handler();
+      expect(mockS3.send).toHaveBeenCalledWith(
+        expect.objectContaining({ Key: 'attachments/trash-old/file.pdf' }),
+      );
+    });
+
+    test('returns junkMoved: 0 and trashDeleted: 1', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 1 });
+    });
+  });
+
+  describe('trash messages newer than 30 days', () => {
+    const recentTrash = {
+      messageId: 'trash-recent',
+      folder: 'trash',
+      folderMovedAt: daysAgo(5),
+    };
+
+    beforeEach(() => {
+      mockDynamo.send.mockResolvedValueOnce({ Items: [recentTrash] });
+    });
+
+    test('does not delete recent trash messages', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 0 });
+      expect(mockS3.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('messages without folderMovedAt', () => {
+    const noTimestampItem = {
+      messageId: 'old-no-timestamp',
+      folder: 'junk',
+    };
+
+    beforeEach(() => {
+      mockDynamo.send.mockResolvedValueOnce({ Items: [noTimestampItem] });
+    });
+
+    test('skips messages without folderMovedAt', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 0 });
+    });
+  });
+
+  describe('DynamoDB pagination', () => {
+    const page1JunkItem = {
+      messageId: 'junk-page1',
+      folder: 'junk',
+      folderMovedAt: daysAgo(35),
+    };
+    const page2TrashItem = {
+      messageId: 'trash-page2',
+      folder: 'trash',
+      folderMovedAt: daysAgo(40),
+      bodyTextS3Key: 'parsed/trash-page2/body.txt',
+      attachments: [],
+    };
+
+    beforeEach(() => {
+      mockDynamo.send
+        .mockResolvedValueOnce({ Items: [page1JunkItem], LastEvaluatedKey: { messageId: 'junk-page1' } }) // page 1
+        .mockResolvedValueOnce({ Items: [page2TrashItem] })  // page 2 (no LastEvaluatedKey)
+        .mockResolvedValue({});                              // UpdateCommand + DeleteCommand
+      mockS3.send.mockResolvedValue({});
+    });
+
+    test('processes items across multiple scan pages', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 1, trashDeleted: 1 });
+    });
+  });
+
+  describe('empty table', () => {
+    beforeEach(() => {
+      mockDynamo.send.mockResolvedValueOnce({ Items: [] });
+    });
+
+    test('returns zeros and makes no mutations', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 0 });
+      expect(mockDynamo.send).toHaveBeenCalledTimes(1); // only the scan
+      expect(mockS3.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trash with no S3 keys', () => {
+    const trashNoKeys = {
+      messageId: 'trash-no-keys',
+      folder: 'trash',
+      folderMovedAt: daysAgo(31),
+    };
+
+    beforeEach(() => {
+      mockDynamo.send
+        .mockResolvedValueOnce({ Items: [trashNoKeys] })
+        .mockResolvedValue({});
+      mockS3.send.mockResolvedValue({});
+    });
+
+    test('deletes the DynamoDB record without calling S3', async () => {
+      const result = await handler();
+      expect(result).toEqual({ junkMoved: 0, trashDeleted: 1 });
+      expect(mockS3.send).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- Write folderMovedAt on PATCH when folder field changes
- Add cleanup-expired-messages Lambda: moves 30-day-old junk to trash, permanently deletes 30-day-old trash from DynamoDB + S3
- Wire Lambda with daily EventBridge cron rule (03:00 UTC) in CDK stack
- Update CI to install cleanup Lambda deps in test, cdk-diff, and deploy jobs
- Add unit tests for Lambda and folderMovedAt PATCH behaviour

closes #187