### PR TITLE
[feat]: implement user management and profile settings (#200)

### DIFF
--- a/app/__tests__/components/settings/change-password-dialog.test.tsx
+++ b/app/__tests__/components/settings/change-password-dialog.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChangePasswordDialog } from '@/components/settings/change-password-dialog';
+
+function renderDialog() {
+  return render(
+    <ChangePasswordDialog trigger={<button data-testid="open-btn">Change password</button>} />,
+  );
+}
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+describe('ChangePasswordDialog', () => {
+  test('opens dialog on trigger click', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('current-password-input')).toBeInTheDocument();
+    expect(screen.getByTestId('new-password-input')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-password-input')).toBeInTheDocument();
+  });
+
+  test('shows error when new passwords do not match', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    await user.type(screen.getByTestId('current-password-input'), 'OldPass123!');
+    await user.type(screen.getByTestId('new-password-input'), 'NewPass123!');
+    await user.type(screen.getByTestId('confirm-password-input'), 'DifferentPass!');
+    await user.click(screen.getByTestId('change-password-submit'));
+    expect(screen.getByTestId('change-password-error')).toHaveTextContent(
+      'New passwords do not match',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('shows error when new password is too short', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    await user.type(screen.getByTestId('current-password-input'), 'OldPass123!');
+    await user.type(screen.getByTestId('new-password-input'), 'short');
+    await user.type(screen.getByTestId('confirm-password-input'), 'short');
+    await user.click(screen.getByTestId('change-password-submit'));
+    expect(screen.getByTestId('change-password-error')).toHaveTextContent(
+      'at least 8 characters',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('calls API and shows success on valid submission', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    await user.type(screen.getByTestId('current-password-input'), 'OldPass123!');
+    await user.type(screen.getByTestId('new-password-input'), 'NewPass123!');
+    await user.type(screen.getByTestId('confirm-password-input'), 'NewPass123!');
+    await user.click(screen.getByTestId('change-password-submit'));
+    await waitFor(() =>
+      expect(screen.getByText('Password changed successfully.')).toBeInTheDocument(),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/auth/change-password',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('shows API error message on failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Incorrect username or password.' }),
+    });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    await user.type(screen.getByTestId('current-password-input'), 'WrongPass!');
+    await user.type(screen.getByTestId('new-password-input'), 'NewPass123!');
+    await user.type(screen.getByTestId('confirm-password-input'), 'NewPass123!');
+    await user.click(screen.getByTestId('change-password-submit'));
+    await waitFor(() =>
+      expect(screen.getByTestId('change-password-error')).toHaveTextContent(
+        'Incorrect username or password.',
+      ),
+    );
+  });
+
+  test('resets form when dialog is closed and reopened', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderDialog();
+    await user.click(screen.getByTestId('open-btn'));
+    await user.type(screen.getByTestId('current-password-input'), 'OldPass123!');
+    await user.type(screen.getByTestId('new-password-input'), 'Bad');
+    await user.type(screen.getByTestId('confirm-password-input'), 'Mismatch');
+    await user.click(screen.getByTestId('change-password-submit'));
+    expect(screen.getByTestId('change-password-error')).toBeInTheDocument();
+    // Close
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    // Reopen
+    await user.click(screen.getByTestId('open-btn'));
+    expect(screen.queryByTestId('change-password-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('current-password-input')).toHaveValue('');
+  });
+});

--- a/app/__tests__/components/settings/settings-view.test.tsx
+++ b/app/__tests__/components/settings/settings-view.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SettingsView } from '@/components/settings/settings-view';
@@ -53,6 +54,71 @@ jest.mock('@/components/addresses/delete-address-dialog', () => ({
   ),
 }));
 
+jest.mock('@/components/settings/change-password-dialog', () => ({
+  ChangePasswordDialog: ({ trigger }: { trigger: React.ReactNode }) => (
+    <div data-testid="change-password-dialog">{trigger}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/select', () => {
+  const React = require('react');
+
+  const SelectItem = ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  );
+  const SelectContent = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  const SelectTrigger = (_props: unknown) => null;
+  const SelectValue = () => null;
+
+  const Select = ({ children, onValueChange, value }: {
+    children: React.ReactNode;
+    onValueChange?: (v: string) => void;
+    value?: string;
+  }) => {
+    let testId: string | undefined;
+    const items: React.ReactNode[] = [];
+
+    React.Children.forEach(children, (child: React.ReactElement) => {
+      if (!React.isValidElement(child)) return;
+      if ((child as React.ReactElement).type === SelectTrigger) {
+        testId = (child as React.ReactElement<{ 'data-testid'?: string }>).props['data-testid'];
+      }
+      if ((child as React.ReactElement).type === SelectContent) {
+        React.Children.forEach(
+          (child as React.ReactElement<{ children: React.ReactNode }>).props.children,
+          (item: React.ReactElement) => {
+            if (React.isValidElement(item) && item.type === SelectItem) {
+              items.push(item);
+            }
+          },
+        );
+      }
+    });
+
+    return (
+      <select
+        data-testid={testId}
+        value={value ?? ''}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => onValueChange?.(e.target.value)}
+      >
+        {items}
+      </select>
+    );
+  };
+
+  return { Select, SelectTrigger, SelectContent, SelectItem, SelectValue };
+});
+
+const mockSetPreferenceCookie = jest.fn();
+const mockGetPreferenceCookie = jest.fn().mockReturnValue(null);
+
+jest.mock('@/lib/preferences', () => ({
+  PREFERRED_ADDRESS_COOKIE: 'hermes_preferred_address',
+  SIDEBAR_STATE_COOKIE: 'sidebar_state',
+  setPreferenceCookie: (...args: unknown[]) => mockSetPreferenceCookie(...args),
+  getPreferenceCookie: (...args: unknown[]) => mockGetPreferenceCookie(...args),
+}));
+
 const DOMAINS = [
   { domain: 'example.com', status: 'Verified' as const },
   { domain: 'pending.com', status: 'Pending' as const },
@@ -90,6 +156,8 @@ beforeEach(() => {
   global.fetch = jest.fn();
   mockPush.mockReset();
   mockRefresh.mockReset();
+  mockSetPreferenceCookie.mockReset();
+  mockGetPreferenceCookie.mockReturnValue(null);
 });
 
 afterEach(() => {
@@ -207,6 +275,74 @@ describe('SettingsView', () => {
         'href',
         `/inbox/${encodeURIComponent('hello@example.com')}/msg-1`,
       );
+    });
+  });
+
+  describe('preferences section', () => {
+    test('renders preferred address select', () => {
+      renderView();
+      expect(screen.getByTestId('preferred-address-select')).toBeInTheDocument();
+    });
+
+    test('renders sidebar default select', () => {
+      renderView();
+      expect(screen.getByTestId('sidebar-default-select')).toBeInTheDocument();
+    });
+
+    test('shows no-addresses fallback when address list is empty', () => {
+      renderView({ addresses: [] });
+      expect(screen.getByText('No addresses')).toBeInTheDocument();
+    });
+
+    test('saving preferred address writes preference cookie', async () => {
+      const user = userEvent.setup();
+      renderView();
+      await user.selectOptions(
+        screen.getByTestId('preferred-address-select'),
+        'info@example.com',
+      );
+      expect(mockSetPreferenceCookie).toHaveBeenCalledWith(
+        'hermes_preferred_address',
+        'info@example.com',
+      );
+    });
+
+    test('saving sidebar default writes preference cookie', async () => {
+      const user = userEvent.setup();
+      renderView();
+      await user.selectOptions(
+        screen.getByTestId('sidebar-default-select'),
+        'collapsed',
+      );
+      expect(mockSetPreferenceCookie).toHaveBeenCalledWith('sidebar_state', 'false');
+    });
+
+    test('loads existing preferred address from cookie on mount', () => {
+      mockGetPreferenceCookie.mockImplementation((name: string) =>
+        name === 'hermes_preferred_address' ? 'info@example.com' : null,
+      );
+      renderView();
+      expect(screen.getByTestId('preferred-address-select')).toBeInTheDocument();
+    });
+
+    test('loads collapsed sidebar default from cookie on mount', () => {
+      mockGetPreferenceCookie.mockImplementation((name: string) =>
+        name === 'sidebar_state' ? 'false' : null,
+      );
+      renderView();
+      expect(screen.getByTestId('sidebar-default-select')).toBeInTheDocument();
+    });
+  });
+
+  describe('account section', () => {
+    test('renders change password button', () => {
+      renderView();
+      expect(screen.getByTestId('change-password-btn')).toBeInTheDocument();
+    });
+
+    test('renders change password dialog', () => {
+      renderView();
+      expect(screen.getByTestId('change-password-dialog')).toBeInTheDocument();
     });
   });
 });

--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { AppSidebar } from '@/components/layout/sidebar';
 import { ConditionalLayout } from '@/components/layout/conditional-layout';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { WebSocketProvider } from '@/components/ws-context';
+import { SIDEBAR_STATE_COOKIE } from '@/lib/preferences';
 
 interface Address {
   email: string;
@@ -40,9 +41,12 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const addresses = await getAddresses(token);
   const wsEndpoint = process.env.NEXT_PUBLIC_WEBSOCKET_ENDPOINT ?? '';
 
+  const sidebarStateCookie = cookieStore.get(SIDEBAR_STATE_COOKIE)?.value;
+  const defaultSidebarOpen = sidebarStateCookie === undefined ? true : sidebarStateCookie === 'true';
+
   return (
     <WebSocketProvider token={token} wsEndpoint={wsEndpoint}>
-      <SidebarProvider className="h-svh">
+      <SidebarProvider className="h-svh" defaultOpen={defaultSidebarOpen}>
         <AppSidebar addresses={addresses} />
         <SidebarInset className="flex flex-col min-h-0">
           <ConditionalLayout>{children}</ConditionalLayout>

--- a/app/app/(app)/page.tsx
+++ b/app/app/(app)/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { PREFERRED_ADDRESS_COOKIE } from '@/lib/preferences';
 
 const BASE = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
 
@@ -12,6 +13,7 @@ interface Address {
 export default async function DefaultPage() {
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
+  const preferredAddress = cookieStore.get(PREFERRED_ADDRESS_COOKIE)?.value;
 
   const res = await fetch(`${BASE}/api/addresses`, {
     headers: { Cookie: cookieHeader },
@@ -28,7 +30,11 @@ export default async function DefaultPage() {
       });
 
     if (active.length > 0) {
-      redirect(`/inbox/${encodeURIComponent(active[0].email)}`);
+      const target =
+        preferredAddress && active.some((a) => a.email === preferredAddress)
+          ? preferredAddress
+          : active[0].email;
+      redirect(`/inbox/${encodeURIComponent(target)}`);
     }
   }
 

--- a/app/app/api/auth/change-password/route.ts
+++ b/app/app/api/auth/change-password/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { changePassword, CognitoAuthError } from '@/lib/auth/cognito';
+import { requireAuth } from '@/lib/auth/require-auth';
+import { ACCESS_TOKEN_COOKIE } from '@/lib/auth/cookies';
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireAuth(req);
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const accessToken = req.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+  if (!accessToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { currentPassword?: string; newPassword?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { currentPassword, newPassword } = body;
+  if (!currentPassword || !newPassword) {
+    return NextResponse.json({ error: 'currentPassword and newPassword are required' }, { status: 400 });
+  }
+
+  if (newPassword.length < 8) {
+    return NextResponse.json({ error: 'New password must be at least 8 characters' }, { status: 400 });
+  }
+
+  try {
+    await changePassword(accessToken, currentPassword, newPassword);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    if (err instanceof CognitoAuthError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Failed to change password' }, { status: 500 });
+  }
+}

--- a/app/components/settings/change-password-dialog.tsx
+++ b/app/components/settings/change-password-dialog.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2 } from 'lucide-react';
+
+interface ChangePasswordDialogProps {
+  trigger: React.ReactNode;
+}
+
+export function ChangePasswordDialog({ trigger }: ChangePasswordDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  function resetForm() {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setError(null);
+    setSuccess(false);
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) resetForm();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError('New password must be at least 8 characters');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+
+      const data = await res.json().catch(() => ({})) as { error?: string };
+
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to change password');
+        return;
+      }
+
+      setSuccess(true);
+      setTimeout(() => setOpen(false), 1500);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Change password</DialogTitle>
+        </DialogHeader>
+
+        {success ? (
+          <p className="text-sm text-green-600 py-4 text-center">Password changed successfully.</p>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="current-password">Current password</Label>
+              <Input
+                id="current-password"
+                type="password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                disabled={isSubmitting}
+                required
+                data-testid="current-password-input"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="new-password">New password</Label>
+              <Input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                disabled={isSubmitting}
+                required
+                data-testid="new-password-input"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="confirm-password">Confirm new password</Label>
+              <Input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                disabled={isSubmitting}
+                required
+                data-testid="confirm-password-input"
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive" data-testid="change-password-error">{error}</p>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting} data-testid="change-password-submit">
+                {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Change password'}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/settings/settings-view.tsx
+++ b/app/components/settings/settings-view.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   Globe,
   AtSign,
@@ -13,11 +20,20 @@ import {
   Clock,
   ChevronDown,
   Plus,
+  KeyRound,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { AddDomainDialog } from '@/components/domains/add-domain-dialog';
 import { AddAddressDialog } from '@/components/addresses/add-address-dialog';
 import { DeleteAddressDialog } from '@/components/addresses/delete-address-dialog';
+import { ChangePasswordDialog } from '@/components/settings/change-password-dialog';
+import {
+  PREFERRED_ADDRESS_COOKIE,
+  SIDEBAR_STATE_COOKIE,
+  setPreferenceCookie,
+  getPreferenceCookie,
+} from '@/lib/preferences';
 
 interface Domain {
   domain: string;
@@ -70,6 +86,25 @@ export function SettingsView({
   const [domains, setDomains] = useState<Domain[]>(initialDomains);
   const [addresses, setAddresses] = useState<Address[]>(initialAddresses);
   const [openDomains, setOpenDomains] = useState<Set<string>>(new Set());
+  const [preferredAddress, setPreferredAddress] = useState<string>('');
+  const [sidebarDefault, setSidebarDefault] = useState<'expanded' | 'collapsed'>('expanded');
+
+  useEffect(() => {
+    const pref = getPreferenceCookie(PREFERRED_ADDRESS_COOKIE);
+    if (pref) setPreferredAddress(pref);
+    const sidebar = getPreferenceCookie(SIDEBAR_STATE_COOKIE);
+    setSidebarDefault(sidebar === 'false' ? 'collapsed' : 'expanded');
+  }, []);
+
+  function handlePreferredAddressChange(email: string) {
+    setPreferredAddress(email);
+    setPreferenceCookie(PREFERRED_ADDRESS_COOKIE, email);
+  }
+
+  function handleSidebarDefaultChange(value: 'expanded' | 'collapsed') {
+    setSidebarDefault(value);
+    setPreferenceCookie(SIDEBAR_STATE_COOKIE, value === 'expanded' ? 'true' : 'false');
+  }
 
   function toggleDomain(d: string) {
     setOpenDomains((prev) => {
@@ -288,6 +323,103 @@ export function SettingsView({
           })
         )}
       </div>
+
+      {/* Preferences */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm font-medium">Preferences</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {/* Preferred Address */}
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Default address</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Address shown first when you open Hermes.
+              </p>
+            </div>
+            {addresses.filter((a) => a.status !== 'deleted').length === 0 ? (
+              <p className="text-sm text-muted-foreground">No addresses</p>
+            ) : (
+              <Select
+                value={preferredAddress || addresses.filter((a) => a.status !== 'deleted')[0]?.email}
+                onValueChange={handlePreferredAddressChange}
+              >
+                <SelectTrigger
+                  className="w-[220px] text-sm"
+                  data-testid="preferred-address-select"
+                >
+                  <SelectValue placeholder="Select address" />
+                </SelectTrigger>
+                <SelectContent>
+                  {addresses
+                    .filter((a) => a.status !== 'deleted')
+                    .map((addr) => (
+                      <SelectItem key={addr.email} value={addr.email}>
+                        {addr.email}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          {/* Sidebar default */}
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Sidebar default</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Whether the sidebar starts expanded or collapsed.
+              </p>
+            </div>
+            <Select
+              value={sidebarDefault}
+              onValueChange={(v) => handleSidebarDefaultChange(v as 'expanded' | 'collapsed')}
+            >
+              <SelectTrigger
+                className="w-[140px] text-sm"
+                data-testid="sidebar-default-select"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="expanded">Expanded</SelectItem>
+                <SelectItem value="collapsed">Collapsed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Account */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4 text-muted-foreground" />
+            <CardTitle className="text-sm font-medium">Account</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium">Password</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Update your account password.
+              </p>
+            </div>
+            <ChangePasswordDialog
+              trigger={
+                <Button variant="outline" size="sm" data-testid="change-password-btn">
+                  Change password
+                </Button>
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Recent Activity */}
       <Card>

--- a/app/lib/auth/cognito.ts
+++ b/app/lib/auth/cognito.ts
@@ -1,6 +1,7 @@
 import {
   CognitoIdentityProviderClient,
   InitiateAuthCommand,
+  ChangePasswordCommand,
   type InitiateAuthCommandOutput,
 } from '@aws-sdk/client-cognito-identity-provider';
 
@@ -56,6 +57,25 @@ export async function signIn(username: string, password: string): Promise<AuthTo
     idToken: auth.IdToken,
     expiresIn: auth.ExpiresIn ?? 3600,
   };
+}
+
+export async function changePassword(
+  accessToken: string,
+  previousPassword: string,
+  proposedPassword: string,
+): Promise<void> {
+  try {
+    await cognitoClient.send(
+      new ChangePasswordCommand({
+        AccessToken: accessToken,
+        PreviousPassword: previousPassword,
+        ProposedPassword: proposedPassword,
+      }),
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to change password';
+    throw new CognitoAuthError(message);
+  }
 }
 
 export async function refreshAccessToken(refreshToken: string): Promise<AuthTokens> {

--- a/app/lib/preferences.ts
+++ b/app/lib/preferences.ts
@@ -1,0 +1,15 @@
+export const PREFERRED_ADDRESS_COOKIE = 'hermes_preferred_address';
+export const SIDEBAR_STATE_COOKIE = 'sidebar_state';
+export const PREFERENCE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+export function setPreferenceCookie(name: string, value: string, maxAge = PREFERENCE_COOKIE_MAX_AGE) {
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAge}; SameSite=Lax`;
+}
+
+export function getPreferenceCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}


### PR DESCRIPTION
- Change password via Cognito ChangePasswordCommand with dedicated API route
- Preferred default address saved as cookie, used for home page redirect
- Sidebar default state (expanded/collapsed) persisted via cookie and applied on load
- Preferences and Account sections added to settings page, Recent Activity moved to last

closes #200