### PR TITLE
[fix]: prevent password field reset and add loading state on login (#208)

### DIFF
--- a/app/__tests__/app/login/login-form.test.tsx
+++ b/app/__tests__/app/login/login-form.test.tsx
@@ -2,32 +2,14 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LoginForm } from '@/app/login/login-form';
 
-// ── Mock server action ────────────────────────────────────────────────────────
 const mockLoginAction = jest.fn();
 jest.mock('@/app/login/actions', () => ({
   loginAction: (...args: unknown[]) => mockLoginAction(...args),
 }));
 
-// ── Mock next/navigation ──────────────────────────────────────────────────────
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-}));
-
-// React's useActionState needs to be shimmed for jsdom
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useActionState: (
-    action: (state: unknown, formData: FormData) => Promise<unknown>,
-    initialState: unknown,
-  ) => {
-    const [state, setState] = jest.requireActual('react').useState(initialState);
-    const dispatch = async (formData: FormData) => {
-      const newState = await action(state, formData);
-      setState(newState);
-    };
-    return [state, dispatch, false];
-  },
 }));
 
 describe('LoginForm', () => {
@@ -47,6 +29,11 @@ describe('LoginForm', () => {
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
   });
 
+  test('does not show error alert on initial render', () => {
+    render(<LoginForm />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   test('shows error alert when action returns an error', async () => {
     mockLoginAction.mockResolvedValueOnce({ error: 'Invalid username or password.' });
 
@@ -63,9 +50,19 @@ describe('LoginForm', () => {
     });
   });
 
-  test('does not show error alert on initial render', () => {
+  test('clears password field on error', async () => {
+    mockLoginAction.mockResolvedValueOnce({ error: 'Invalid username or password.' });
+
+    const user = userEvent.setup();
     render(<LoginForm />);
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'wrongpass');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/password/i)).toHaveValue('');
+    });
   });
 
   test('redirects to / on successful login', async () => {
@@ -80,6 +77,57 @@ describe('LoginForm', () => {
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/');
+    });
+  });
+
+  test('password field retains value after successful login before navigation', async () => {
+    mockLoginAction.mockResolvedValueOnce({ success: true });
+
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'mypassword');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
+    expect(screen.getByLabelText(/password/i)).toHaveValue('mypassword');
+  });
+
+  test('button shows spinner and is disabled while loading', async () => {
+    let resolveAction!: (v: unknown) => void;
+    mockLoginAction.mockImplementationOnce(() => new Promise((res) => { resolveAction = res; }));
+
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeDisabled();
+      expect(screen.getByLabelText(/username/i)).toBeDisabled();
+      expect(screen.getByLabelText(/password/i)).toBeDisabled();
+    });
+
+    resolveAction({ success: true });
+  });
+
+  test('button stays disabled after success state before navigation', async () => {
+    mockLoginAction.mockResolvedValueOnce({ success: true });
+
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/username/i), 'admin');
+    await user.type(screen.getByLabelText(/password/i), 'password');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeDisabled();
     });
   });
 });

--- a/app/app/login/login-form.tsx
+++ b/app/app/login/login-form.tsx
@@ -1,30 +1,49 @@
 'use client';
 
-import { useActionState, useEffect } from 'react';
+import { useTransition, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { loginAction, type LoginState } from './actions';
+import { loginAction } from './actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-
-const initialState: LoginState = {};
+import { Loader2 } from 'lucide-react';
 
 export function LoginForm() {
   const router = useRouter();
-  const [state, formAction, isPending] = useActionState(loginAction, initialState);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [success, setSuccess] = useState(false);
+  const [password, setPassword] = useState('');
 
   useEffect(() => {
-    if (state.success) {
+    if (success) {
       router.push('/');
     }
-  }, [state.success, router]);
+  }, [success, router]);
+
+  const isLoading = isPending || success;
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    setError(undefined);
+    startTransition(async () => {
+      const result = await loginAction({}, formData);
+      if (result.error) {
+        setError(result.error);
+        setPassword('');
+      } else if (result.success) {
+        setSuccess(true);
+      }
+    });
+  }
 
   return (
-    <form action={formAction} className="space-y-4">
-      {state.error && (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
         <Alert variant="destructive">
-          <AlertDescription>{state.error}</AlertDescription>
+          <AlertDescription>{error}</AlertDescription>
         </Alert>
       )}
 
@@ -36,7 +55,7 @@ export function LoginForm() {
           type="text"
           autoComplete="username"
           required
-          disabled={isPending}
+          disabled={isLoading}
           placeholder="admin"
         />
       </div>
@@ -49,12 +68,15 @@ export function LoginForm() {
           type="password"
           autoComplete="current-password"
           required
-          disabled={isPending}
+          disabled={isLoading}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
         />
       </div>
 
-      <Button type="submit" className="w-full" disabled={isPending}>
-        {isPending ? 'Signing in...' : 'Sign in'}
+      <Button type="submit" className="w-full" disabled={isLoading}>
+        {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        Sign in
       </Button>
     </form>
   );


### PR DESCRIPTION
## Summary

- Replaced `useActionState` + form action with `useTransition` + `onSubmit` + `e.preventDefault()` to prevent React from calling `form.reset()` after the server action, which was causing the password field to clear before navigation
- Password field is now a controlled input — retained through successful login, cleared explicitly on error
- Button shows a loading spinner and is disabled during the API call and through to navigation (covers the gap between `isPending → false` and `router.push` firing)

## Test plan

- [ ] Submit with valid credentials — password field stays visible until app loads
- [ ] Submit with invalid credentials — error alert shown, password field cleared
- [ ] Loading spinner appears on Sign in button during the API call
- [ ] Button and inputs remain disabled until navigation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
