### PR TITLE
[fix]: prevent long email subject from expanding layout and pushing h…

### DIFF
--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -48,7 +48,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     <WebSocketProvider token={token} wsEndpoint={wsEndpoint}>
       <SidebarProvider className="h-svh" defaultOpen={defaultSidebarOpen}>
         <AppSidebar addresses={addresses} />
-        <SidebarInset className="flex flex-col min-h-0">
+        <SidebarInset className="flex flex-col min-h-0 overflow-hidden">
           <ConditionalLayout>{children}</ConditionalLayout>
         </SidebarInset>
       </SidebarProvider>

--- a/app/components/layout/topbar.tsx
+++ b/app/components/layout/topbar.tsx
@@ -24,8 +24,8 @@ export function Topbar() {
   return (
     <header className="flex h-14 shrink-0 items-center gap-3 border-b px-4">
       <SidebarTrigger />
-      <h1 className="text-sm font-medium text-foreground truncate">{title}</h1>
-      <div className="ml-auto">
+      <h1 className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">{title}</h1>
+      <div className="shrink-0">
         <ThemeToggle />
       </div>
     </header>

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -204,7 +204,7 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   return (
     <div className="flex flex-col h-full min-h-0">
       <div className="flex items-center justify-between border-b px-4 h-14 shrink-0 gap-2">
-        <div className="flex flex-col min-w-0">
+        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
           <span className="text-sm font-semibold truncate">{message.subject}</span>
           <span className="text-xs text-muted-foreground truncate">
             {message.from ?? message.sender} · {new Date(message.receivedAt).toLocaleString()}


### PR DESCRIPTION
…eader controls (#211)

Add overflow-hidden to SidebarInset to contain horizontal overflow at the root level. Fix message detail subject container with flex-1 and overflow-hidden so it fills available space and truncates correctly. Fix topbar h1 with flex-1 min-w-0 so the title truncates in flex layout, and switch ThemeToggle wrapper to shrink-0 to keep it anchored at the right edge.

closes #211