### PR TITLE
[fix]: restore @aws-sdk/client-ses — still required by domains and ad…

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/client-dynamodb": "^3.1034.0",
     "@aws-sdk/client-route-53": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.1037.0",
+    "@aws-sdk/client-ses": "^3.1034.0",
     "@aws-sdk/client-sesv2": "^3.1063.0",
     "@aws-sdk/lib-dynamodb": "^3.1034.0",
     "@aws-sdk/s3-request-presigner": "^3.1037.0",


### PR DESCRIPTION
…dresses routes (#215)

Receipt rule management and domain identity verification commands are SES v1-only with no SES v2 equivalents, so the package cannot be removed yet.

closes #215