### PR TITLE
[feat]: migrate drafts endpoint and send mutation to RTK Query (#218)

### DIFF
--- a/app/__tests__/components/drafts/compose-editor.test.tsx
+++ b/app/__tests__/components/drafts/compose-editor.test.tsx
@@ -8,10 +8,26 @@ jest.mock('@/lib/navigation-guard', () => ({
 }));
 
 const mockPush = jest.fn();
-const mockRefresh = jest.fn();
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockSendEmailUnwrap = jest.fn().mockResolvedValue({ messageId: 'new-msg' });
+const mockSendEmail = jest.fn(() => ({ unwrap: mockSendEmailUnwrap }));
+const mockInvalidateTags = jest.fn(() => ({ type: 'test/invalidate' }));
+jest.mock('@/store/api', () => ({
+  useSendEmailMutation: () => [mockSendEmail],
+  apiSlice: {
+    util: {
+      invalidateTags: (...args: unknown[]) => mockInvalidateTags(...args),
+    },
+  },
+}));
+
+const mockDispatch = jest.fn((action) => action);
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
 }));
 
 jest.mock('@/components/ui/scroll-area', () => ({
@@ -49,8 +65,12 @@ const EMPTY_DRAFT = {
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  mockSendEmailUnwrap.mockResolvedValue({ messageId: 'new-msg' });
   mockPush.mockReset();
-  mockRefresh.mockReset();
+  mockDispatch.mockClear();
+  mockSendEmail.mockClear();
+  mockSendEmailUnwrap.mockClear();
+  mockInvalidateTags.mockClear();
 });
 
 afterEach(() => {
@@ -140,29 +160,24 @@ describe('ComposeEditor', () => {
       });
     });
 
-    test('calls POST /api/messages on send with valid To', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => ({ messageId: 'new-msg' }),
-      });
+    test('calls sendEmail mutation on send with valid To', async () => {
       const user = userEvent.setup();
       render(<ComposeEditor draft={DRAFT} address="me@hermes.com" />);
 
       await user.click(screen.getByTestId('compose-send-button'));
 
       await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalledWith(
-          '/api/messages',
-          expect.objectContaining({ method: 'POST' }),
+        expect(mockSendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({
+            from: DRAFT.from,
+            to: DRAFT.to,
+            draftId: DRAFT.draftId,
+          }),
         );
       });
     });
 
     test('navigates to drafts list after successful send', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        json: async () => ({ messageId: 'new-msg' }),
-      });
       const user = userEvent.setup();
       render(<ComposeEditor draft={DRAFT} address="me@hermes.com" />);
 
@@ -176,10 +191,7 @@ describe('ComposeEditor', () => {
     });
 
     test('shows error when send fails', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-        json: async () => ({ error: 'Send failed' }),
-      });
+      mockSendEmailUnwrap.mockRejectedValueOnce({ data: { error: 'Send failed' } });
       const user = userEvent.setup();
       render(<ComposeEditor draft={DRAFT} address="me@hermes.com" />);
 

--- a/app/__tests__/components/drafts/drafts-list.test.tsx
+++ b/app/__tests__/components/drafts/drafts-list.test.tsx
@@ -4,16 +4,35 @@ import { DraftsList } from '@/components/drafts/drafts-list';
 
 const mockPush = jest.fn();
 const mockPathname = jest.fn().mockReturnValue('/drafts/me%40hermes.com');
+const mockDispatch = jest.fn((action) => action);
 
-const mockRefresh = jest.fn();
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useRouter: () => ({ push: mockPush }),
   usePathname: () => mockPathname(),
 }));
 
 jest.mock('@/lib/navigation-guard', () => ({
   tryNavigate: jest.fn((fn: () => void) => fn()),
 }));
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+const mockUpdateQueryData = jest.fn(() => ({ type: 'test/patch', undo: jest.fn() }));
+const mockInvalidateTags = jest.fn(() => ({ type: 'test/invalidate' }));
+
+jest.mock('@/store/api', () => ({
+  useGetDraftsQuery: jest.fn(),
+  apiSlice: {
+    util: {
+      updateQueryData: (...args: unknown[]) => mockUpdateQueryData(...args),
+      invalidateTags: (...args: unknown[]) => mockInvalidateTags(...args),
+    },
+  },
+}));
+
+import { useGetDraftsQuery } from '@/store/api';
 
 const ADDRESS = 'me@hermes.com';
 
@@ -43,8 +62,15 @@ const NO_SUBJECT_DRAFT = {
   updatedAt: '2026-05-10T09:00:00.000Z',
 };
 
+function mockQuery(drafts: typeof COMPOSE_DRAFT[], isLoading = false) {
+  (useGetDraftsQuery as jest.Mock).mockReturnValue({ data: { drafts }, isLoading });
+}
+
 beforeEach(() => {
   mockPush.mockReset();
+  mockDispatch.mockClear();
+  mockUpdateQueryData.mockClear();
+  mockInvalidateTags.mockClear();
   mockPathname.mockReturnValue('/drafts/me%40hermes.com');
   global.fetch = jest.fn();
 });
@@ -55,61 +81,77 @@ afterEach(() => {
 
 describe('DraftsList', () => {
   test('shows "Drafts" header', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByText('Drafts')).toBeInTheDocument();
   });
 
+  test('shows loading state while fetching', () => {
+    mockQuery([], true);
+    render(<DraftsList address={ADDRESS} />);
+    expect(screen.getByTestId('drafts-loading')).toBeInTheDocument();
+  });
+
   test('shows empty state when no drafts', () => {
-    render(<DraftsList drafts={[]} address={ADDRESS} />);
+    mockQuery([]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByTestId('drafts-empty-state')).toBeInTheDocument();
     expect(screen.getByText(/no drafts saved yet/i)).toBeInTheDocument();
   });
 
   test('renders draft cards when drafts exist', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT, REPLY_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT, REPLY_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByTestId('drafts-list')).toBeInTheDocument();
     expect(screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`)).toBeInTheDocument();
     expect(screen.getByTestId(`draft-row-${REPLY_DRAFT.draftId}`)).toBeInTheDocument();
   });
 
   test('shows subject for drafts with subject', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   test('shows "(no subject)" for drafts without subject', () => {
-    render(<DraftsList drafts={[NO_SUBJECT_DRAFT]} address={ADDRESS} />);
+    mockQuery([NO_SUBJECT_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByText('(no subject)')).toBeInTheDocument();
   });
 
   test('shows recipient address', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByText('recipient@example.com')).toBeInTheDocument();
   });
 
   test('shows "No recipient" when to is missing', () => {
     const draft = { ...COMPOSE_DRAFT, to: undefined };
-    render(<DraftsList drafts={[draft]} address={ADDRESS} />);
+    mockQuery([draft as typeof COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByText('No recipient')).toBeInTheDocument();
   });
 
   test('applies active styling to the currently open draft', () => {
     mockPathname.mockReturnValue(`/drafts/me%40hermes.com/${COMPOSE_DRAFT.draftId}`);
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     const card = screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`);
     expect(card.className).toContain('border-accent-foreground/20');
   });
 
   test('does not apply active styling to non-active drafts', () => {
     mockPathname.mockReturnValue(`/drafts/me%40hermes.com/${COMPOSE_DRAFT.draftId}`);
-    render(<DraftsList drafts={[COMPOSE_DRAFT, REPLY_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT, REPLY_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     const inactiveCard = screen.getByTestId(`draft-row-${REPLY_DRAFT.draftId}`);
     expect(inactiveCard.className).not.toContain('border-accent-foreground/20');
   });
 
   test('clicking new composition draft navigates to draft editor URL', async () => {
+    mockQuery([COMPOSE_DRAFT]);
     const user = userEvent.setup();
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    render(<DraftsList address={ADDRESS} />);
 
     await user.click(screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`));
 
@@ -119,8 +161,9 @@ describe('DraftsList', () => {
   });
 
   test('clicking reply draft navigates to message with draftId and mode params', async () => {
+    mockQuery([REPLY_DRAFT]);
     const user = userEvent.setup();
-    render(<DraftsList drafts={[REPLY_DRAFT]} address={ADDRESS} />);
+    render(<DraftsList address={ADDRESS} />);
 
     await user.click(screen.getByTestId(`draft-row-${REPLY_DRAFT.draftId}`));
 
@@ -138,66 +181,101 @@ describe('DraftsList', () => {
 
 describe('DraftsList — bulk actions', () => {
   test('renders bulk action toolbar with select-all checkbox', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByTestId('select-all-checkbox')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-delete-button')).toBeInTheDocument();
   });
 
   test('does not show junk button for drafts', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.queryByTestId('bulk-junk-button')).not.toBeInTheDocument();
   });
 
   test('does not show mark read/unread buttons for drafts', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.queryByTestId('bulk-mark-read-button')).not.toBeInTheDocument();
     expect(screen.queryByTestId('bulk-mark-unread-button')).not.toBeInTheDocument();
   });
 
   test('delete button is disabled when nothing is selected', () => {
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
     expect(screen.getByTestId('bulk-delete-button')).toBeDisabled();
   });
 
   test('clicking a draft checkbox selects it and enables delete button', async () => {
+    mockQuery([COMPOSE_DRAFT]);
     const user = userEvent.setup();
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    render(<DraftsList address={ADDRESS} />);
     await user.click(screen.getByLabelText('Select email'));
     expect(screen.getByTestId('bulk-delete-button')).not.toBeDisabled();
     expect(screen.getByTestId('selection-count')).toHaveTextContent('1 selected');
   });
 
   test('select all checkbox selects all drafts', async () => {
+    mockQuery([COMPOSE_DRAFT, REPLY_DRAFT]);
     const user = userEvent.setup();
-    render(<DraftsList drafts={[COMPOSE_DRAFT, REPLY_DRAFT]} address={ADDRESS} />);
+    render(<DraftsList address={ADDRESS} />);
     await user.click(screen.getByTestId('select-all-checkbox'));
     expect(screen.getByTestId('selection-count')).toHaveTextContent('2 selected');
   });
 
-  test('bulk delete calls DELETE for each selected draft and removes them from list', async () => {
+  test('bulk delete optimistically patches cache and calls DELETE for each draft', async () => {
+    const mockUndo = jest.fn();
+    mockUpdateQueryData.mockReturnValueOnce({ type: 'test/patch', undo: mockUndo });
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
     const user = userEvent.setup();
-    render(<DraftsList drafts={[COMPOSE_DRAFT, REPLY_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT, REPLY_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
+
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-delete-button'));
+
     await waitFor(() => {
-      expect(screen.queryByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`)).not.toBeInTheDocument();
-      expect(screen.queryByTestId(`draft-row-${REPLY_DRAFT.draftId}`)).not.toBeInTheDocument();
+      expect(mockUpdateQueryData).toHaveBeenCalledWith(
+        'getDrafts',
+        ADDRESS,
+        expect.any(Function),
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/drafts/'),
+        expect.objectContaining({ method: 'DELETE' }),
+      );
     });
-    expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/drafts/'),
-      expect.objectContaining({ method: 'DELETE' }),
-    );
   });
 
-  test('bulk delete rolls back drafts that fail', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+  test('bulk delete invalidates Draft tag after completion', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const user = userEvent.setup();
-    render(<DraftsList drafts={[COMPOSE_DRAFT]} address={ADDRESS} />);
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
+
     await user.click(screen.getByLabelText('Select email'));
     await user.click(screen.getByTestId('bulk-delete-button'));
+
     await waitFor(() => {
-      expect(screen.getByTestId(`draft-row-${COMPOSE_DRAFT.draftId}`)).toBeInTheDocument();
+      expect(mockInvalidateTags).toHaveBeenCalledWith(['Draft']);
+    });
+  });
+
+  test('bulk delete rolls back cache when delete fails', async () => {
+    const mockUndo = jest.fn();
+    mockUpdateQueryData.mockReturnValueOnce({ type: 'test/patch', undo: mockUndo });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    const user = userEvent.setup();
+    mockQuery([COMPOSE_DRAFT]);
+    render(<DraftsList address={ADDRESS} />);
+
+    await user.click(screen.getByLabelText('Select email'));
+    await user.click(screen.getByTestId('bulk-delete-button'));
+
+    await waitFor(() => {
+      expect(mockUndo).toHaveBeenCalled();
     });
   });
 });

--- a/app/__tests__/store/store.test.ts
+++ b/app/__tests__/store/store.test.ts
@@ -30,4 +30,12 @@ describe('apiSlice', () => {
   it('exposes endpoints object', () => {
     expect(apiSlice.endpoints).toBeDefined();
   });
+
+  it('exposes getDrafts query endpoint', () => {
+    expect(apiSlice.endpoints.getDrafts).toBeDefined();
+  });
+
+  it('exposes sendEmail mutation endpoint', () => {
+    expect(apiSlice.endpoints.sendEmail).toBeDefined();
+  });
 });

--- a/app/app/(app)/drafts/[address]/layout.tsx
+++ b/app/app/(app)/drafts/[address]/layout.tsx
@@ -1,41 +1,5 @@
-import { cookies } from 'next/headers';
-import { redirect } from 'next/navigation';
 import { MailboxLayout } from '@/components/layout/mailbox-layout';
 import { DraftsList } from '@/components/drafts/drafts-list';
-
-interface Draft {
-  draftId: string;
-  from?: string;
-  to?: string;
-  subject?: string;
-  body?: string;
-  cc?: string;
-  bcc?: string;
-  attachmentKeys?: string[];
-  inReplyToMessageId?: string;
-  updatedAt: string;
-}
-
-async function getDrafts(address: string): Promise<Draft[]> {
-  const cookieStore = await cookies();
-  const token = cookieStore.get('access_token')?.value;
-  if (!token) redirect('/login');
-
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
-  const res = await fetch(
-    `${baseUrl}/api/drafts?from=${encodeURIComponent(address)}`,
-    {
-      headers: { Cookie: `access_token=${token}` },
-      cache: 'no-store',
-    },
-  );
-
-  if (res.status === 401) redirect('/login');
-  if (!res.ok) return [];
-
-  const data = await res.json();
-  return data.drafts ?? [];
-}
 
 interface Props {
   params: Promise<{ address: string }>;
@@ -45,11 +9,10 @@ interface Props {
 export default async function DraftsAddressLayout({ params, children }: Props) {
   const { address } = await params;
   const decoded = decodeURIComponent(address);
-  const drafts = await getDrafts(decoded);
 
   return (
     <MailboxLayout
-      list={<DraftsList drafts={drafts} address={decoded} />}
+      list={<DraftsList address={decoded} />}
       detail={children}
     />
   );

--- a/app/components/drafts/compose-editor.tsx
+++ b/app/components/drafts/compose-editor.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { setNavigationGuard } from '@/lib/navigation-guard';
+import { useSendEmailMutation, apiSlice } from '@/store/api';
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from '@/store';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -40,6 +43,8 @@ function validateEmail(value: string): boolean {
 
 export function ComposeEditor({ draft, address }: ComposeEditorProps) {
   const router = useRouter();
+  const dispatch = useDispatch<AppDispatch>();
+  const [sendEmail] = useSendEmailMutation();
 
   const [to, setTo] = useState(draft.to ?? '');
   const [subject, setSubject] = useState(draft.subject ?? '');
@@ -131,27 +136,18 @@ export function ComposeEditor({ draft, address }: ComposeEditorProps) {
     setIsSending(true);
     setSendError(null);
     try {
-      const res = await fetch('/api/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          from: draft.from,
-          to,
-          subject,
-          body,
-          draftId: draft.draftId,
-        }),
-      });
-      if (!res.ok) {
-        const data = await res.json() as { error?: string };
-        setSendError(data.error ?? 'Failed to send email');
-        return;
-      }
+      await sendEmail({
+        from: draft.from ?? '',
+        to,
+        subject,
+        body,
+        draftId: draft.draftId,
+      }).unwrap();
       shouldDeleteOnNavigateRef.current = false; // API already deleted the draft
       router.push(`/drafts/${encodeURIComponent(address)}`);
-      router.refresh();
-    } catch {
-      setSendError('Failed to send email. Please try again.');
+    } catch (err) {
+      const message = (err as { data?: { error?: string } })?.data?.error;
+      setSendError(message ?? 'Failed to send email. Please try again.');
     } finally {
       setIsSending(false);
     }
@@ -160,13 +156,13 @@ export function ComposeEditor({ draft, address }: ComposeEditorProps) {
   async function doDiscard() {
     shouldDeleteOnNavigateRef.current = false;
     await fetch(`/api/drafts/${draft.draftId}`, { method: 'DELETE' }).catch(() => null);
+    dispatch(apiSlice.util.invalidateTags(['Draft']));
     const pendingNav = pendingNavigationRef.current;
     pendingNavigationRef.current = null;
     if (pendingNav) {
       pendingNav();
     } else {
       router.push(`/drafts/${encodeURIComponent(address)}`);
-      router.refresh();
     }
   }
 

--- a/app/components/drafts/drafts-list.tsx
+++ b/app/components/drafts/drafts-list.tsx
@@ -1,45 +1,33 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { FileText } from 'lucide-react';
+import { FileText, Loader2 } from 'lucide-react';
 import { MailboxCard, formatMailboxDate } from '@/components/mailbox-card';
 import { BulkActionToolbar } from '@/components/bulk-action-toolbar';
 import { tryNavigate } from '@/lib/navigation-guard';
-
-interface Draft {
-  draftId: string;
-  from?: string;
-  to?: string;
-  subject?: string;
-  body?: string;
-  cc?: string;
-  bcc?: string;
-  attachmentKeys?: string[];
-  inReplyToMessageId?: string;
-  updatedAt: string;
-}
+import { useGetDraftsQuery, apiSlice, type Draft } from '@/store/api';
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from '@/store';
 
 interface DraftsListProps {
-  drafts: Draft[];
-  address?: string;
+  address: string;
 }
 
-export function DraftsList({ drafts: initialDrafts, address }: DraftsListProps) {
+export function DraftsList({ address }: DraftsListProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [drafts, setDrafts] = useState<Draft[]>(initialDrafts);
+  const dispatch = useDispatch<AppDispatch>();
   const [pendingDraftId, setPendingDraftId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const { data, isLoading } = useGetDraftsQuery(address);
+  const drafts = data?.drafts ?? [];
 
   const activeDraftId = (() => {
     const segments = pathname.split('/');
     return segments.length >= 4 ? segments[3] : null;
   })();
-
-  useEffect(() => {
-    setPendingDraftId(null);
-  }, [pathname]);
 
   function handleDraftClick(draft: Draft) {
     if (draft.inReplyToMessageId) {
@@ -79,12 +67,17 @@ export function DraftsList({ drafts: initialDrafts, address }: DraftsListProps) 
 
   async function handleBulkDelete() {
     const ids = [...selectedIds];
-    const removed = drafts.filter((d) => ids.includes(d.draftId));
-    setDrafts((prev) => prev.filter((d) => !selectedIds.has(d.draftId)));
+    const draftsToRemove = drafts.filter((d) => ids.includes(d.draftId));
+
+    const patchResult = dispatch(
+      apiSlice.util.updateQueryData('getDrafts', address, (draft) => {
+        draft.drafts = draft.drafts.filter((d) => !ids.includes(d.draftId));
+      }),
+    );
     setSelectedIds(new Set());
 
     if (activeDraftId && ids.includes(activeDraftId)) {
-      router.push(address ? `/drafts/${encodeURIComponent(address)}` : '/drafts');
+      router.push(`/drafts/${encodeURIComponent(address)}`);
     }
 
     const results = await Promise.allSettled(
@@ -93,17 +86,29 @@ export function DraftsList({ drafts: initialDrafts, address }: DraftsListProps) 
       ),
     );
 
-    const failed = removed.filter((_, i) => {
+    const failed = draftsToRemove.filter((_, i) => {
       const r = results[i];
       return r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.ok);
     });
+
     if (failed.length > 0) {
-      setDrafts((prev) => {
-        const existing = new Set(prev.map((d) => d.draftId));
-        return [...failed.filter((d) => !existing.has(d.draftId)), ...prev];
-      });
+      patchResult.undo();
+      const succeededIds = new Set(
+        ids.filter((_, i) => {
+          const r = results[i];
+          return r.status === 'fulfilled' && r.value.ok;
+        }),
+      );
+      if (succeededIds.size > 0) {
+        dispatch(
+          apiSlice.util.updateQueryData('getDrafts', address, (draft) => {
+            draft.drafts = draft.drafts.filter((d) => !succeededIds.has(d.draftId));
+          }),
+        );
+      }
     }
-    router.refresh();
+
+    dispatch(apiSlice.util.invalidateTags(['Draft']));
   }
 
   return (
@@ -121,7 +126,11 @@ export function DraftsList({ drafts: initialDrafts, address }: DraftsListProps) 
       />
 
       <div className="flex-1 overflow-y-auto">
-        {drafts.length === 0 ? (
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20 h-full" data-testid="drafts-loading">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : drafts.length === 0 ? (
           <div
             className="flex flex-col items-center justify-center gap-3 py-20 text-center h-full"
             data-testid="drafts-empty-state"

--- a/app/components/messages/compose-sheet.tsx
+++ b/app/components/messages/compose-sheet.tsx
@@ -18,8 +18,10 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { BookMarked, Paperclip, Send, Trash2, X } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useCompose, type ComposeInitialData } from '@/components/compose-context';
+import { useSendEmailMutation, apiSlice } from '@/store/api';
+import { useDispatch } from 'react-redux';
+import type { AppDispatch } from '@/store';
 
 interface Address {
   email: string;
@@ -70,7 +72,8 @@ interface ComposeSheetInnerProps {
 }
 
 function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInnerProps) {
-  const router = useRouter();
+  const dispatch = useDispatch<AppDispatch>();
+  const [sendEmail] = useSendEmailMutation();
   const activeAddresses = addresses.filter((a) => a.status !== 'deleted');
 
   const form = useForm<ComposeFormValues>({
@@ -176,29 +179,20 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
     setIsSending(true);
     setSendError(null);
     try {
-      const res = await fetch('/api/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          from: values.from,
-          to: values.to,
-          cc: values.cc || undefined,
-          bcc: values.bcc || undefined,
-          subject: values.subject,
-          body: values.body,
-          attachmentKeys: attachments.map((a) => a.s3Key),
-          draftId: draftIdRef.current ?? undefined,
-        }),
-      });
-      if (!res.ok) {
-        const data = await res.json() as { error?: string };
-        setSendError(data.error ?? 'Failed to send email');
-        return;
-      }
+      await sendEmail({
+        from: values.from,
+        to: values.to,
+        cc: values.cc || undefined,
+        bcc: values.bcc || undefined,
+        subject: values.subject,
+        body: values.body,
+        attachmentKeys: attachments.map((a) => a.s3Key),
+        draftId: draftIdRef.current ?? undefined,
+      }).unwrap();
       onClose();
-      router.refresh();
-    } catch {
-      setSendError('Failed to send email. Please try again.');
+    } catch (err) {
+      const message = (err as { data?: { error?: string } })?.data?.error;
+      setSendError(message ?? 'Failed to send email. Please try again.');
     } finally {
       setIsSending(false);
     }
@@ -207,9 +201,9 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
   async function handleDiscard() {
     if (draftIdRef.current) {
       await fetch(`/api/drafts/${draftIdRef.current}`, { method: 'DELETE' }).catch(() => null);
+      dispatch(apiSlice.util.invalidateTags(['Draft']));
     }
     onClose();
-    router.refresh();
   }
 
   function formatSavedAt(date: Date) {
@@ -362,7 +356,7 @@ function ComposeSheetInner({ addresses, initialData, onClose }: ComposeSheetInne
                     <Textarea
                       {...field}
                       placeholder="Write your message…"
-                      className="min-h-[200px] resize-y"
+                      className="min-h-50 resize-y"
                       onChange={(e) => {
                         field.onChange(e);
                       }}

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -2,9 +2,65 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 export type TagType = 'Message' | 'Draft' | 'Folder' | 'Thread';
 
+export interface Draft {
+  draftId: string;
+  from?: string;
+  to?: string;
+  subject?: string;
+  body?: string;
+  cc?: string;
+  bcc?: string;
+  attachmentKeys?: string[];
+  inReplyToMessageId?: string;
+  updatedAt: string;
+}
+
+export interface GetDraftsResponse {
+  drafts: Draft[];
+}
+
+export interface SendEmailPayload {
+  from: string;
+  to: string;
+  cc?: string;
+  bcc?: string;
+  subject: string;
+  body: string;
+  attachmentKeys?: string[];
+  draftId?: string;
+}
+
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
   tagTypes: ['Message', 'Draft', 'Folder', 'Thread'] satisfies TagType[],
-  endpoints: () => ({}),
+  endpoints: (builder) => ({
+    getDrafts: builder.query<GetDraftsResponse, string>({
+      query: (address) => `/drafts?from=${encodeURIComponent(address)}`,
+      providesTags: ['Draft'],
+    }),
+    sendEmail: builder.mutation<{ messageId: string }, SendEmailPayload>({
+      query: (payload) => ({
+        url: '/messages',
+        method: 'POST',
+        body: payload,
+      }),
+      async onQueryStarted({ draftId, from }, { dispatch, queryFulfilled }) {
+        if (!draftId) return;
+        const patchResult = dispatch(
+          apiSlice.util.updateQueryData('getDrafts', from, (draft) => {
+            draft.drafts = draft.drafts.filter((d) => d.draftId !== draftId);
+          }),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patchResult.undo();
+        }
+      },
+      invalidatesTags: (_result, error) => (error ? [] : ['Draft']),
+    }),
+  }),
 });
+
+export const { useGetDraftsQuery, useSendEmailMutation } = apiSlice;


### PR DESCRIPTION
Fixes stale draft bug where sending an email left a ghost draft in the list. sendEmail mutation invalidates the Draft tag and optimistically removes the draft from the cache before the network round-trip completes. DraftsList migrated from prop-based useState to useGetDraftsQuery.

closes #218