### PR TITLE
[feat]: migrate remaining message endpoints and remove custom event s…

### DIFF
--- a/app/__tests__/components/inbox/message-list.test.tsx
+++ b/app/__tests__/components/inbox/message-list.test.tsx
@@ -18,6 +18,60 @@ jest.mock('@/components/ws-context', () => ({
   useWs: () => ({ subscribe: mockSubscribe }),
 }));
 
+// Module-level shared state for RTK mock
+let mockMessages: ReturnType<typeof buildMessages>;
+let mockNextCursor: string | null = null;
+let triggerRender: (() => void) | null = null;
+
+const mockMoveMessage = jest.fn();
+const mockMarkReadStatus = jest.fn();
+const mockDeleteMessage = jest.fn();
+const mockTriggerLoadMore = jest.fn();
+const mockDispatch = jest.fn((action: unknown) => action);
+
+const mockUpdateQueryData = jest.fn(
+  (_endpoint: string, _args: unknown, updater: (d: { messages: typeof INBOUND_MESSAGES; nextCursor: string | null }) => void) => {
+    const draft = { messages: mockMessages, nextCursor: mockNextCursor };
+    updater(draft as unknown as { messages: typeof INBOUND_MESSAGES; nextCursor: string | null });
+    mockMessages = draft.messages;
+    mockNextCursor = draft.nextCursor;
+    triggerRender?.();
+    return { type: 'mock/patch', undo: jest.fn() };
+  },
+);
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('@/store/api', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react');
+
+  function useGetMessagesQueryMock() {
+    const [, setTick] = React.useState(0);
+    // Capture the forceUpdate function synchronously during render
+    triggerRender = () => setTick((n: number) => n + 1);
+    return { data: { messages: mockMessages, nextCursor: mockNextCursor }, isFetching: false };
+  }
+
+  return {
+    useGetMessagesQuery: useGetMessagesQueryMock,
+    useLazyGetMessagesQuery: jest.fn(() => [mockTriggerLoadMore, { isFetching: false }]),
+    useMarkReadStatusMutation: jest.fn(() => [mockMarkReadStatus]),
+    useMoveMessageMutation: jest.fn(() => [mockMoveMessage]),
+    useDeleteMessageMutation: jest.fn(() => [mockDeleteMessage]),
+    apiSlice: {
+      util: {
+        updateQueryData: (...args: Parameters<typeof mockUpdateQueryData>) =>
+          mockUpdateQueryData(...args),
+      },
+    },
+  };
+});
+
+function buildMessages<T extends readonly unknown[]>(arr: T) { return arr as unknown as typeof INBOUND_MESSAGES; }
+
 const INBOUND_MESSAGES = [
   {
     messageId: 'msg-1',
@@ -71,10 +125,137 @@ const DEFAULT_OUTBOUND_PROPS = {
   folderLabel: 'Sent',
 };
 
+type MessageListProps = {
+  address: string;
+  direction: 'inbound' | 'outbound';
+  folder?: 'inbox' | 'junk' | 'trash';
+  initialMessages: typeof INBOUND_MESSAGES;
+  initialNextCursor: string | null;
+  folderLabel: string;
+};
+
+function setupMutationMocks() {
+  mockMoveMessage.mockImplementation(
+    async ({ messageId, targetFolder, fromAddress, fromFolder, fromDirection }: {
+      messageId: string; targetFolder: string; fromAddress: string;
+      fromFolder?: string; fromDirection?: string;
+    }) => {
+      const savedMessages = [...mockMessages];
+      mockUpdateQueryData(
+        'getMessages',
+        { address: fromAddress, folder: fromFolder, direction: fromDirection },
+        (draft) => {
+          draft.messages = (draft.messages as typeof INBOUND_MESSAGES).filter(
+            (m) => m.messageId !== messageId,
+          ) as typeof INBOUND_MESSAGES;
+        },
+      );
+      const res = await (global.fetch as jest.Mock)(
+        `/api/messages/${encodeURIComponent(messageId)}`,
+        { method: 'PATCH', body: JSON.stringify({ folder: targetFolder }) },
+      );
+      if (!(res as { ok: boolean }).ok) {
+        mockMessages = savedMessages;
+        triggerRender?.();
+        return { error: {} };
+      }
+      return { data: {} };
+    },
+  );
+
+  mockMarkReadStatus.mockImplementation(
+    async ({ messageId, isRead, address, folder, direction }: {
+      messageId: string; isRead: boolean; address: string;
+      folder?: string; direction?: string;
+    }) => {
+      const savedMessages = mockMessages.map((m) => ({ ...m }));
+      mockUpdateQueryData(
+        'getMessages',
+        { address, folder, direction },
+        (draft) => {
+          const m = (draft.messages as typeof INBOUND_MESSAGES).find((msg) => msg.messageId === messageId);
+          if (m) (m as { isRead: boolean }).isRead = isRead;
+        },
+      );
+      const res = await (global.fetch as jest.Mock)(
+        `/api/messages/${encodeURIComponent(messageId)}`,
+        { method: 'PATCH', body: JSON.stringify({ isRead }) },
+      );
+      if (!(res as { ok: boolean }).ok) {
+        mockMessages = savedMessages;
+        triggerRender?.();
+        return { error: {} };
+      }
+      return { data: {} };
+    },
+  );
+
+  mockDeleteMessage.mockImplementation(
+    async ({ messageId, address, folder, direction }: {
+      messageId: string; address: string; folder?: string; direction?: string;
+    }) => {
+      const savedMessages = [...mockMessages];
+      mockUpdateQueryData(
+        'getMessages',
+        { address, folder, direction },
+        (draft) => {
+          draft.messages = (draft.messages as typeof INBOUND_MESSAGES).filter(
+            (m) => m.messageId !== messageId,
+          ) as typeof INBOUND_MESSAGES;
+        },
+      );
+      const res = await (global.fetch as jest.Mock)(
+        `/api/messages/${encodeURIComponent(messageId)}`,
+        { method: 'DELETE' },
+      );
+      if (!(res as { ok: boolean }).ok) {
+        mockMessages = savedMessages;
+        triggerRender?.();
+        return { error: {} };
+      }
+      return { data: {} };
+    },
+  );
+
+  mockTriggerLoadMore.mockImplementation(
+    async ({ address, folder, direction, cursor }: {
+      address: string; folder?: string; direction?: string; cursor?: string;
+    }) => {
+      const params = new URLSearchParams({ address });
+      if (folder) params.set('folder', folder);
+      else if (direction) params.set('direction', direction);
+      if (cursor) params.set('cursor', cursor);
+      const res = await (global.fetch as jest.Mock)(`/api/messages?${params.toString()}`);
+      if (res && (res as { ok: boolean }).ok) {
+        const data = await (res as { json: () => Promise<{ messages: typeof INBOUND_MESSAGES; nextCursor: string | null }> }).json();
+        mockMessages = [...mockMessages, ...data.messages] as typeof INBOUND_MESSAGES;
+        mockNextCursor = data.nextCursor;
+        triggerRender?.();
+      }
+    },
+  );
+}
+
+function renderWithMessages(
+  props: MessageListProps,
+  messages: typeof INBOUND_MESSAGES = INBOUND_MESSAGES,
+  nextCursor: string | null = null,
+) {
+  mockMessages = messages.map((m) => ({ ...m })) as typeof INBOUND_MESSAGES;
+  mockNextCursor = nextCursor;
+  return render(<MessageList {...props} />);
+}
+
 beforeEach(() => {
+  mockMessages = INBOUND_MESSAGES.map((m) => ({ ...m })) as typeof INBOUND_MESSAGES;
+  mockNextCursor = null;
+  triggerRender = null;
   global.fetch = jest.fn();
   wsHandler = null;
   mockSubscribe.mockClear();
+  mockDispatch.mockClear();
+  mockUpdateQueryData.mockClear();
+  setupMutationMocks();
 });
 
 afterEach(() => {
@@ -83,30 +264,30 @@ afterEach(() => {
 
 describe('MessageList — inbox (inbound)', () => {
   test('renders folder label in header', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByText('Inbox')).toBeInTheDocument();
   });
 
   test('renders inbound message rows with sender name', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByText('alice@test.com')).toBeInTheDocument();
     expect(screen.getByText('bob@test.com')).toBeInTheDocument();
   });
 
   test('renders message subjects', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByText('Hello')).toBeInTheDocument();
     expect(screen.getByText('World')).toBeInTheDocument();
   });
 
   test('falls back to sender field when from is absent', () => {
     const msg = [{ ...INBOUND_MESSAGES[0], from: undefined, sender: 'legacy@test.com' }];
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialMessages={msg} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, msg as typeof INBOUND_MESSAGES);
     expect(screen.getByText('legacy@test.com')).toBeInTheDocument();
   });
 
   test('shows unread badge for unread inbound messages', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByLabelText('Unread')).toBeInTheDocument();
   });
 
@@ -124,7 +305,7 @@ describe('MessageList — inbox (inbound)', () => {
       ok: true,
       json: async () => ({ message: wsMessage }),
     });
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     act(() => {
       wsHandler?.({ type: 'new_message', address: 'hello@example.com', messageId: 'msg-ws' });
     });
@@ -133,7 +314,7 @@ describe('MessageList — inbox (inbound)', () => {
   });
 
   test('ignores WebSocket events for a different address', async () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     act(() => {
       wsHandler?.({ type: 'new_message', address: 'other@example.com', messageId: 'x' });
     });
@@ -146,80 +327,12 @@ describe('MessageList — inbox (inbound)', () => {
       ok: true,
       json: async () => ({ message: INBOUND_MESSAGES[0] }),
     });
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     act(() => {
       wsHandler?.({ type: 'new_message', address: 'hello@example.com', messageId: 'msg-1' });
     });
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect(screen.getAllByText('alice@test.com')).toHaveLength(1);
-  });
-});
-
-describe('MessageList — sent (outbound)', () => {
-  test('renders folder label in header', () => {
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
-    expect(screen.getByText('Sent')).toBeInTheDocument();
-  });
-
-  test('renders outbound rows with recipient name', () => {
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
-    expect(screen.getByText('recipient@test.com')).toBeInTheDocument();
-    expect(screen.getByText('Re: Hello')).toBeInTheDocument();
-  });
-
-  test('does not show unread badge for outbound messages', () => {
-    const unread = [{ ...OUTBOUND_MESSAGES[0], isRead: false }];
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} initialMessages={unread} />);
-    expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
-  });
-
-  test('passes direction=outbound to API on pagination', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ messages: [], nextCursor: null }),
-    });
-    const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} initialNextCursor="cursor1" />);
-    await user.click(screen.getByRole('button', { name: /load more/i }));
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('direction=outbound'));
-    });
-  });
-
-  test('does not subscribe to WebSocket events in sent view', () => {
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
-    expect(mockSubscribe).not.toHaveBeenCalled();
-  });
-});
-
-describe('MessageList — hermes:readstatus event', () => {
-  test('clears unread badge when hermes:readstatus fires with isRead=true', async () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
-    expect(screen.getByLabelText('Unread')).toBeInTheDocument();
-
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('hermes:readstatus', { detail: { messageId: 'msg-2', isRead: true } }),
-      );
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
-    });
-  });
-
-  test('restores unread badge when hermes:readstatus fires with isRead=false', async () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
-
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('hermes:readstatus', { detail: { messageId: 'msg-1', isRead: false } }),
-      );
-    });
-
-    await waitFor(() => {
-      expect(screen.getAllByLabelText('Unread')).toHaveLength(2);
-    });
   });
 
   test('WS message from field is displayed after fetch', async () => {
@@ -236,7 +349,7 @@ describe('MessageList — hermes:readstatus event', () => {
         },
       }),
     });
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     act(() => {
       wsHandler?.({ type: 'new_message', address: 'hello@example.com', messageId: 'msg-ws2' });
     });
@@ -244,56 +357,55 @@ describe('MessageList — hermes:readstatus event', () => {
   });
 });
 
-describe('MessageList — hermes:inboxcount', () => {
-  test('dispatches hermes:inboxcount on mount with unread count', () => {
-    const events: CustomEvent[] = [];
-    const handler = (e: Event) => events.push(e as CustomEvent);
-    window.addEventListener('hermes:inboxcount', handler);
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
-    expect(events.length).toBeGreaterThan(0);
-    expect(events[0].detail).toEqual({ address: 'hello@example.com', unreadCount: 1 });
-    window.removeEventListener('hermes:inboxcount', handler);
+describe('MessageList — sent (outbound)', () => {
+  test('renders folder label in header', () => {
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES);
+    expect(screen.getByText('Sent')).toBeInTheDocument();
   });
 
-  test('does not dispatch hermes:inboxcount for outbound direction', () => {
-    const events: CustomEvent[] = [];
-    const handler = (e: Event) => events.push(e as CustomEvent);
-    window.addEventListener('hermes:inboxcount', handler);
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
-    expect(events).toHaveLength(0);
-    window.removeEventListener('hermes:inboxcount', handler);
+  test('renders outbound rows with recipient name', () => {
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES);
+    expect(screen.getByText('recipient@test.com')).toBeInTheDocument();
+    expect(screen.getByText('Re: Hello')).toBeInTheDocument();
   });
 
-  test('updates hermes:inboxcount when hermes:readstatus marks a message read', async () => {
-    const events: CustomEvent[] = [];
-    const handler = (e: Event) => events.push(e as CustomEvent);
-    window.addEventListener('hermes:inboxcount', handler);
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('hermes:readstatus', { detail: { messageId: 'msg-2', isRead: true } }),
-      );
+  test('does not show unread badge for outbound messages', () => {
+    const unread = [{ ...OUTBOUND_MESSAGES[0], isRead: false }];
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, unread as typeof INBOUND_MESSAGES);
+    expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
+  });
+
+  test('passes direction=outbound to API on pagination', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ messages: [], nextCursor: null }),
     });
+    const user = userEvent.setup();
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES, 'cursor1');
+    await user.click(screen.getByRole('button', { name: /load more/i }));
     await waitFor(() => {
-      const last = events[events.length - 1];
-      expect(last.detail).toEqual({ address: 'hello@example.com', unreadCount: 0 });
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('direction=outbound'));
     });
-    window.removeEventListener('hermes:inboxcount', handler);
+  });
+
+  test('does not subscribe to WebSocket events in sent view', () => {
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES);
+    expect(mockSubscribe).not.toHaveBeenCalled();
   });
 });
 
 describe('MessageList — folder prop (junk)', () => {
-  const JUNK_PROPS = {
+  const JUNK_PROPS: MessageListProps = {
     address: 'hello@example.com',
-    direction: 'inbound' as const,
-    folder: 'junk' as const,
+    direction: 'inbound',
+    folder: 'junk',
     initialMessages: INBOUND_MESSAGES,
     initialNextCursor: null,
     folderLabel: 'Junk',
   };
 
   test('renders Junk folder label', () => {
-    render(<MessageList {...JUNK_PROPS} />);
+    renderWithMessages(JUNK_PROPS);
     expect(screen.getByText('Junk')).toBeInTheDocument();
   });
 
@@ -302,7 +414,7 @@ describe('MessageList — folder prop (junk)', () => {
     const mockPush = jest.fn();
     useRouter.mockReturnValue({ push: mockPush, refresh: jest.fn() });
     const user = userEvent.setup();
-    render(<MessageList {...JUNK_PROPS} />);
+    renderWithMessages(JUNK_PROPS);
     await user.click(screen.getByTestId('message-row-msg-1'));
     expect(mockPush).toHaveBeenCalledWith('/junk/hello%40example.com/msg-1');
   });
@@ -313,7 +425,7 @@ describe('MessageList — folder prop (junk)', () => {
       json: async () => ({ messages: [], nextCursor: null }),
     });
     const user = userEvent.setup();
-    render(<MessageList {...JUNK_PROPS} initialNextCursor="cursor1" />);
+    renderWithMessages({ ...JUNK_PROPS, initialNextCursor: 'cursor1' }, INBOUND_MESSAGES, 'cursor1');
     await user.click(screen.getByRole('button', { name: /load more/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('folder=junk'));
@@ -321,57 +433,23 @@ describe('MessageList — folder prop (junk)', () => {
   });
 
   test('does not subscribe to WebSocket events for junk folder', () => {
-    render(<MessageList {...JUNK_PROPS} />);
+    renderWithMessages(JUNK_PROPS);
     expect(mockSubscribe).not.toHaveBeenCalled();
-  });
-
-  test('optimistically clears unread badge when clicking an unread junk message', async () => {
-    const { useRouter } = require('next/navigation');
-    useRouter.mockReturnValue({ push: jest.fn(), refresh: jest.fn() });
-    const user = userEvent.setup();
-    render(<MessageList {...JUNK_PROPS} />);
-    expect(screen.getByLabelText('Unread')).toBeInTheDocument();
-    await user.click(screen.getByTestId('message-row-msg-2'));
-    await waitFor(() => {
-      expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
-    });
-  });
-
-  test('does not dispatch hermes:inboxcount for junk folder', () => {
-    const events: CustomEvent[] = [];
-    const handler = (e: Event) => events.push(e as CustomEvent);
-    window.addEventListener('hermes:inboxcount', handler);
-    render(<MessageList {...JUNK_PROPS} />);
-    expect(events).toHaveLength(0);
-    window.removeEventListener('hermes:inboxcount', handler);
-  });
-
-  test('removes message from list when hermes:messageremoved fires', async () => {
-    render(<MessageList {...JUNK_PROPS} />);
-    expect(screen.getByText('alice@test.com')).toBeInTheDocument();
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('hermes:messageremoved', { detail: { messageId: 'msg-1' } }),
-      );
-    });
-    await waitFor(() => {
-      expect(screen.queryByText('alice@test.com')).not.toBeInTheDocument();
-    });
   });
 });
 
 describe('MessageList — folder prop (trash)', () => {
-  const TRASH_PROPS = {
+  const TRASH_PROPS: MessageListProps = {
     address: 'hello@example.com',
-    direction: 'inbound' as const,
-    folder: 'trash' as const,
+    direction: 'inbound',
+    folder: 'trash',
     initialMessages: INBOUND_MESSAGES,
     initialNextCursor: null,
     folderLabel: 'Trash',
   };
 
   test('renders Trash folder label', () => {
-    render(<MessageList {...TRASH_PROPS} />);
+    renderWithMessages(TRASH_PROPS);
     expect(screen.getByText('Trash')).toBeInTheDocument();
   });
 
@@ -380,7 +458,7 @@ describe('MessageList — folder prop (trash)', () => {
     const mockPush = jest.fn();
     useRouter.mockReturnValue({ push: mockPush, refresh: jest.fn() });
     const user = userEvent.setup();
-    render(<MessageList {...TRASH_PROPS} />);
+    renderWithMessages(TRASH_PROPS);
     await user.click(screen.getByTestId('message-row-msg-1'));
     expect(mockPush).toHaveBeenCalledWith('/trash/hello%40example.com/msg-1');
   });
@@ -391,7 +469,7 @@ describe('MessageList — folder prop (trash)', () => {
       json: async () => ({ messages: [], nextCursor: null }),
     });
     const user = userEvent.setup();
-    render(<MessageList {...TRASH_PROPS} initialNextCursor="cursor1" />);
+    renderWithMessages({ ...TRASH_PROPS, initialNextCursor: 'cursor1' }, INBOUND_MESSAGES, 'cursor1');
     await user.click(screen.getByRole('button', { name: /load more/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('folder=trash'));
@@ -399,7 +477,7 @@ describe('MessageList — folder prop (trash)', () => {
   });
 
   test('does not subscribe to WebSocket events for trash folder', () => {
-    render(<MessageList {...TRASH_PROPS} />);
+    renderWithMessages(TRASH_PROPS);
     expect(mockSubscribe).not.toHaveBeenCalled();
   });
 });
@@ -407,17 +485,17 @@ describe('MessageList — folder prop (trash)', () => {
 describe('MessageList — card layout', () => {
   test('renders message snippet when provided', () => {
     const msgs = [{ ...INBOUND_MESSAGES[0], snippet: 'This is a preview of the email body' }];
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialMessages={msgs} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, msgs as typeof INBOUND_MESSAGES);
     expect(screen.getByText('This is a preview of the email body')).toBeInTheDocument();
   });
 
   test('does not render snippet element when snippet is absent', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialMessages={[{ ...INBOUND_MESSAGES[0], snippet: undefined }]} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, [{ ...INBOUND_MESSAGES[0], snippet: undefined }] as typeof INBOUND_MESSAGES);
     expect(screen.queryByTestId('message-snippet')).not.toBeInTheDocument();
   });
 
   test('each message row has rounded card styling', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     const row = screen.getByTestId('message-row-msg-1');
     expect(row.className).toContain('rounded-lg');
   });
@@ -425,29 +503,29 @@ describe('MessageList — card layout', () => {
 
 describe('MessageList — shared', () => {
   test('shows empty state when no messages', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialMessages={[]} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, []);
     expect(screen.getByText(/no messages/i)).toBeInTheDocument();
   });
 
   test('shows Load more button when nextCursor is set', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialNextCursor="cursor123" />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, INBOUND_MESSAGES, 'cursor123');
     expect(screen.getByRole('button', { name: /load more/i })).toBeInTheDocument();
   });
 
   test('does not show Load more when no nextCursor', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
   });
 
   test('shows All mail and Unread filter tabs', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByTestId('filter-all')).toBeInTheDocument();
     expect(screen.getByTestId('filter-unread')).toBeInTheDocument();
   });
 
   test('Unread filter hides read messages', async () => {
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('filter-unread'));
     expect(screen.queryByText('alice@test.com')).not.toBeInTheDocument();
     expect(screen.getByText('bob@test.com')).toBeInTheDocument();
@@ -458,7 +536,7 @@ describe('MessageList — shared', () => {
     const mockPush = jest.fn();
     useRouter.mockReturnValue({ push: mockPush, refresh: jest.fn() });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('message-row-msg-1'));
     expect(mockPush).toHaveBeenCalledWith('/inbox/hello%40example.com/msg-1');
   });
@@ -468,7 +546,7 @@ describe('MessageList — shared', () => {
     const mockPush = jest.fn();
     useRouter.mockReturnValue({ push: mockPush, refresh: jest.fn() });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES);
     await user.click(screen.getByTestId('message-row-msg-out'));
     expect(mockPush).toHaveBeenCalledWith('/sent/hello%40example.com/msg-out');
   });
@@ -477,7 +555,7 @@ describe('MessageList — shared', () => {
     const { useRouter } = require('next/navigation');
     useRouter.mockReturnValue({ push: jest.fn(), refresh: jest.fn() });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByLabelText('Unread')).toBeInTheDocument();
     await user.click(screen.getByTestId('message-row-msg-2'));
     await waitFor(() => {
@@ -490,7 +568,7 @@ describe('MessageList — shared', () => {
     useRouter.mockReturnValue({ push: jest.fn(), refresh: jest.fn() });
     const unreadOutbound = [{ ...OUTBOUND_MESSAGES[0], isRead: false }];
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} initialMessages={unreadOutbound} />);
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, unreadOutbound as typeof INBOUND_MESSAGES);
     await user.click(screen.getByTestId('message-row-msg-out'));
     expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
   });
@@ -498,49 +576,49 @@ describe('MessageList — shared', () => {
 
 describe('MessageList — bulk action toolbar', () => {
   test('renders bulk action toolbar with select-all checkbox', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByTestId('select-all-checkbox')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-delete-button')).toBeInTheDocument();
   });
 
   test('inbox shows mark read and mark unread buttons', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByTestId('bulk-mark-read-button')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-mark-unread-button')).toBeInTheDocument();
   });
 
   test('sent folder does not show mark read or mark unread buttons', () => {
-    render(<MessageList {...DEFAULT_OUTBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_OUTBOUND_PROPS, OUTBOUND_MESSAGES);
     expect(screen.queryByTestId('bulk-mark-read-button')).not.toBeInTheDocument();
     expect(screen.queryByTestId('bulk-mark-unread-button')).not.toBeInTheDocument();
   });
 
   test('junk folder does not show junk button', () => {
-    render(<MessageList
-      address="hello@example.com"
-      direction="inbound"
-      folder="junk"
-      initialMessages={INBOUND_MESSAGES}
-      initialNextCursor={null}
-      folderLabel="Junk"
-    />);
+    renderWithMessages({
+      address: 'hello@example.com',
+      direction: 'inbound',
+      folder: 'junk',
+      initialMessages: INBOUND_MESSAGES,
+      initialNextCursor: null,
+      folderLabel: 'Junk',
+    });
     expect(screen.queryByTestId('bulk-junk-button')).not.toBeInTheDocument();
   });
 
   test('inbox shows junk button', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByTestId('bulk-junk-button')).toBeInTheDocument();
   });
 
   test('action buttons are disabled when nothing is selected', () => {
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByTestId('bulk-delete-button')).toBeDisabled();
     expect(screen.getByTestId('bulk-junk-button')).toBeDisabled();
   });
 
   test('clicking a message checkbox selects it and enables action buttons', async () => {
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     const checkboxes = screen.getAllByLabelText('Select email');
     await user.click(checkboxes[0]);
     expect(screen.getByTestId('bulk-delete-button')).not.toBeDisabled();
@@ -549,14 +627,14 @@ describe('MessageList — bulk action toolbar', () => {
 
   test('select all checkbox selects all displayed messages', async () => {
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('select-all-checkbox'));
     expect(screen.getByTestId('selection-count')).toHaveTextContent('2 selected');
   });
 
   test('clicking select all then unchecking deselects all', async () => {
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('select-all-checkbox'));
     expect(screen.queryByTestId('selection-count')).not.toBeInTheDocument();
@@ -565,7 +643,7 @@ describe('MessageList — bulk action toolbar', () => {
   test('bulk delete (non-trash) PATCHes messages with folder=trash and removes them from list', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-delete-button'));
     await waitFor(() => {
@@ -581,14 +659,14 @@ describe('MessageList — bulk action toolbar', () => {
   test('bulk delete in trash folder calls DELETE endpoint', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
-    render(<MessageList
-      address="hello@example.com"
-      direction="inbound"
-      folder="trash"
-      initialMessages={INBOUND_MESSAGES}
-      initialNextCursor={null}
-      folderLabel="Trash"
-    />);
+    renderWithMessages({
+      address: 'hello@example.com',
+      direction: 'inbound',
+      folder: 'trash',
+      initialMessages: INBOUND_MESSAGES,
+      initialNextCursor: null,
+      folderLabel: 'Trash',
+    });
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-delete-button'));
     await waitFor(() => {
@@ -602,7 +680,7 @@ describe('MessageList — bulk action toolbar', () => {
   test('bulk junk removes messages optimistically and PATCHes folder=junk', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-junk-button'));
     await waitFor(() => {
@@ -617,7 +695,7 @@ describe('MessageList — bulk action toolbar', () => {
   test('bulk mark read PATCHes messages and clears unread badges', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     expect(screen.getByLabelText('Unread')).toBeInTheDocument();
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-mark-read-button'));
@@ -634,7 +712,7 @@ describe('MessageList — bulk action toolbar', () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     const allRead = INBOUND_MESSAGES.map((m) => ({ ...m, isRead: true }));
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} initialMessages={allRead} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS, allRead as typeof INBOUND_MESSAGES);
     expect(screen.queryByLabelText('Unread')).not.toBeInTheDocument();
     await user.click(screen.getByTestId('select-all-checkbox'));
     await user.click(screen.getByTestId('bulk-mark-unread-button'));
@@ -650,7 +728,7 @@ describe('MessageList — bulk action toolbar', () => {
   test('bulk delete rolls back messages that fail', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
     const user = userEvent.setup();
-    render(<MessageList {...DEFAULT_INBOUND_PROPS} />);
+    renderWithMessages(DEFAULT_INBOUND_PROPS);
     const checkboxes = screen.getAllByLabelText('Select email');
     await user.click(checkboxes[0]);
     await user.click(screen.getByTestId('bulk-delete-button'));

--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -45,6 +45,13 @@ jest.mock('@/components/ui/tooltip', () => ({
   TooltipContent: () => null,
 }));
 
+// Mock RTK Query hook — sidebar uses this to derive inbox unread count
+jest.mock('@/store/api', () => ({
+  useGetMessagesQuery: jest.fn(() => ({ data: null, isFetching: false })),
+}));
+
+import { useGetMessagesQuery } from '@/store/api';
+
 const ADDRESSES = [
   { email: 'hello@example.com', domain: 'example.com', status: 'active', unreadCount: 3 },
   { email: 'info@example.com', domain: 'example.com', status: 'active', unreadCount: 0 },
@@ -80,6 +87,7 @@ beforeEach(() => {
   mockPush.mockReset();
   wsHandler = null;
   mockSubscribe.mockClear();
+  (useGetMessagesQuery as jest.Mock).mockReturnValue({ data: null, isFetching: false });
 });
 
 afterEach(() => {
@@ -160,10 +168,29 @@ describe('AppSidebar', () => {
     expect(screen.getByTestId('folder-link-sent')).toHaveAttribute('data-active', 'true');
   });
 
-  test('shows unread badge for selected address inbox count', () => {
+  test('shows unread badge from server-rendered initial count', () => {
     mockPathname.mockReturnValue('/inbox/hello%40example.com');
     renderSidebar();
     expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  test('updates unread badge when RTK Query inbox data is available', async () => {
+    mockPathname.mockReturnValue('/inbox/hello%40example.com');
+    (useGetMessagesQuery as jest.Mock).mockReturnValue({
+      data: {
+        messages: [
+          { messageId: 'msg-1', isRead: false },
+          { messageId: 'msg-2', isRead: false },
+          { messageId: 'msg-3', isRead: true },
+        ],
+        nextCursor: null,
+      },
+      isFetching: false,
+    });
+    renderSidebar();
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
   });
 
   test('increments unread badge when WebSocket new_message event arrives', async () => {
@@ -180,22 +207,6 @@ describe('AppSidebar', () => {
 
     await waitFor(() => {
       expect(screen.getByText('1')).toBeInTheDocument();
-    });
-  });
-
-  test('replaces unread badge when hermes:inboxcount fires', async () => {
-    mockPathname.mockReturnValue('/inbox/hello%40example.com');
-    renderSidebar();
-    expect(screen.getByText('3')).toBeInTheDocument();
-
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('hermes:inboxcount', { detail: { address: 'hello@example.com', unreadCount: 7 } }),
-      );
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('7')).toBeInTheDocument();
     });
   });
 
@@ -362,23 +373,6 @@ describe('AppSidebar', () => {
       await user.click(screen.getByRole('button', { name: /hello@example.com/i }));
       const items = screen.getAllByRole('menuitem');
       expect(items[0]).not.toHaveTextContent(/^\d+$/);
-    });
-
-    test('updates dropdown badge when hermes:inboxcount fires for a non-selected address', async () => {
-      mockPathname.mockReturnValue('/inbox/hello%40example.com');
-      const user = userEvent.setup();
-      renderSidebar(ADDRESSES);
-
-      act(() => {
-        window.dispatchEvent(
-          new CustomEvent('hermes:inboxcount', { detail: { address: 'info@example.com', unreadCount: 5 } }),
-        );
-      });
-
-      await user.click(screen.getByRole('button', { name: /hello@example.com/i }));
-      const items = screen.getAllByRole('menuitem');
-      const infoItem = items.find((el) => el.textContent?.includes('info@example.com'));
-      expect(infoItem).toHaveTextContent('5');
     });
   });
 

--- a/app/__tests__/components/messages/message-detail.test.tsx
+++ b/app/__tests__/components/messages/message-detail.test.tsx
@@ -3,11 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { MessageDetail } from '@/components/messages/message-detail';
 
 const mockPathname = jest.fn().mockReturnValue('/inbox/test%40example.com/msg-1');
-const mockRouterRefresh = jest.fn();
+const mockRouterPush = jest.fn();
 
 jest.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
-  useRouter: () => ({ push: jest.fn(), refresh: mockRouterRefresh }),
+  useRouter: () => ({ push: mockRouterPush, refresh: jest.fn() }),
 }));
 
 const mockToastError = jest.fn();
@@ -21,10 +21,47 @@ jest.mock('sonner', () => ({
   },
 }));
 
+const mockMarkReadStatusFn = jest.fn();
+const mockMoveMessageFn = jest.fn();
+const mockDeleteMessageFn = jest.fn();
+const mockReplyToMessageFn = jest.fn();
+const mockSendEmailFn = jest.fn();
+
+jest.mock('@/store/api', () => ({
+  useMarkReadStatusMutation: jest.fn(() => [mockMarkReadStatusFn]),
+  useMoveMessageMutation: jest.fn(() => [mockMoveMessageFn]),
+  useDeleteMessageMutation: jest.fn(() => [mockDeleteMessageFn]),
+  useReplyToMessageMutation: jest.fn(() => [mockReplyToMessageFn]),
+  useSendEmailMutation: jest.fn(() => [mockSendEmailFn]),
+}));
 
 beforeEach(() => {
-  global.fetch = jest.fn();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
   mockPathname.mockReturnValue('/inbox/test%40example.com/msg-1');
+
+  mockMarkReadStatusFn.mockImplementation(async ({ messageId, isRead }: { messageId: string; isRead: boolean }) => {
+    const res = await (global.fetch as jest.Mock)(
+      `/api/messages/${encodeURIComponent(messageId)}`,
+      { method: 'PATCH', body: JSON.stringify({ isRead }) },
+    );
+    return (res as { ok: boolean }).ok ? { data: {} } : { error: { data: {} } };
+  });
+
+  mockMoveMessageFn.mockImplementation(async ({ messageId, targetFolder }: { messageId: string; targetFolder: string }) => {
+    const res = await (global.fetch as jest.Mock)(
+      `/api/messages/${encodeURIComponent(messageId)}`,
+      { method: 'PATCH', body: JSON.stringify({ folder: targetFolder }) },
+    );
+    return (res as { ok: boolean }).ok ? { data: {} } : { error: { data: {} } };
+  });
+
+  mockDeleteMessageFn.mockImplementation(async ({ messageId }: { messageId: string }) => {
+    const res = await (global.fetch as jest.Mock)(
+      `/api/messages/${encodeURIComponent(messageId)}`,
+      { method: 'DELETE' },
+    );
+    return (res as { ok: boolean }).ok ? { data: {} } : { error: { data: {} } };
+  });
 });
 
 afterEach(() => {
@@ -73,47 +110,22 @@ describe('MessageDetail', () => {
   });
 
   test('marks message as read on mount when unread (inbox)', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     render(<MessageDetail message={{ ...BASE_MSG, isRead: false }} />);
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ isRead: true }) }),
       );
     });
   });
 
-  test('does not call PATCH when message is already read', () => {
+  test('does not call PATCH when message is already read', async () => {
     render(<MessageDetail message={{ ...BASE_MSG, isRead: true }} />);
-    expect(global.fetch).not.toHaveBeenCalledWith(
-      '/api/messages/msg-1',
-      expect.objectContaining({ method: 'PATCH' }),
+    await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+    const patchCalls = (global.fetch as jest.Mock).mock.calls.filter(
+      ([, opts]) => opts?.method === 'PATCH',
     );
-  });
-
-  test('dispatches hermes:readstatus event after auto-marking as read', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:readstatus', (e) => events.push(e as CustomEvent));
-    render(<MessageDetail message={{ ...BASE_MSG, isRead: false }} />);
-    await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1', isRead: true });
-    });
-    window.removeEventListener('hermes:readstatus', (e) => events.push(e as CustomEvent));
-  });
-
-  test('calls router.refresh after auto-marking as read to bust Router Cache', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    render(<MessageDetail message={{ ...BASE_MSG, isRead: false }} />);
-    await waitFor(() => {
-      expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  test('does not call router.refresh when message is already read', () => {
-    render(<MessageDetail message={{ ...BASE_MSG, isRead: true }} />);
-    expect(mockRouterRefresh).not.toHaveBeenCalled();
+    expect(patchCalls).toHaveLength(0);
   });
 
   test('shows Mark as Unread button on inbox route', () => {
@@ -135,13 +147,12 @@ describe('MessageDetail', () => {
   });
 
   test('toggles read status on Mark as Unread click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={{ ...BASE_MSG, isRead: true }} />);
     await user.click(screen.getByRole('button', { name: /mark as unread/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ isRead: false }) }),
       );
     });
@@ -162,7 +173,6 @@ describe('MessageDetail', () => {
   });
 
   test('opens ReplyComposer on Reply click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /^reply$/i }));
@@ -170,7 +180,6 @@ describe('MessageDetail', () => {
   });
 
   test('opens ReplyComposer in replyAll mode on Reply All click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /reply all/i }));
@@ -178,25 +187,23 @@ describe('MessageDetail', () => {
     expect(screen.getByTestId('reply-cc')).toBeInTheDocument();
   });
 
-  test('dispatches hermes:messageremoved after permanent delete from junk', async () => {
+  test('permanent delete from junk calls DELETE and navigates away', async () => {
     mockPathname.mockReturnValue('/junk/test%40example.com/msg-1');
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
     await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/messages/msg-1'),
+        expect.objectContaining({ method: 'DELETE' }),
+      );
     });
-    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
   });
 });
 
 describe('MessageDetail — Move to Trash', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     mockPathname.mockReturnValue('/inbox/test%40example.com/msg-1');
   });
 
@@ -207,34 +214,28 @@ describe('MessageDetail — Move to Trash', () => {
   });
 
   test('calls PATCH with folder=trash when Move to Trash clicked from inbox', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /move to trash/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'trash' }) }),
       );
     });
   });
 
-  test('dispatches hermes:messageremoved after Move to Trash', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  test('navigates to list after Move to Trash succeeds', async () => {
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /move to trash/i }));
     await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+      expect(mockRouterPush).toHaveBeenCalledWith('/inbox/test%40example.com');
     });
-    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
   });
 
   test('calls toast.error when Move to Trash fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /move to trash/i }));
@@ -254,13 +255,13 @@ describe('MessageDetail — Delete (permanent) from junk and trash', () => {
 
   test('trash Delete button uses permanent DELETE', async () => {
     mockPathname.mockReturnValue('/trash/test%40example.com/msg-1');
-    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
@@ -269,39 +270,24 @@ describe('MessageDetail — Delete (permanent) from junk and trash', () => {
 
 describe('MessageDetail — Move to Junk', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     mockPathname.mockReturnValue('/inbox/test%40example.com/msg-1');
   });
 
   test('calls PATCH with folder=junk on Move to Junk click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /move to junk/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'junk' }) }),
       );
     });
   });
 
-  test('dispatches hermes:messageremoved after Move to Junk', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
-    const user = userEvent.setup();
-    render(<MessageDetail message={BASE_MSG} />);
-    await user.click(screen.getByRole('button', { name: /move to junk/i }));
-    await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
-    });
-    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
-  });
-
   test('calls toast.error when Move to Junk fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /move to junk/i }));
@@ -313,7 +299,7 @@ describe('MessageDetail — Move to Junk', () => {
 
 describe('MessageDetail — trash folder', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     mockPathname.mockReturnValue('/trash/test%40example.com/msg-1');
   });
 
@@ -333,36 +319,39 @@ describe('MessageDetail — trash folder', () => {
   });
 
   test('calls PATCH with folder=inbox on Restore to Inbox click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'inbox' }) }),
       );
     });
   });
 
-  test('dispatches hermes:messageremoved after Restore to Inbox from trash', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  test('navigates to list after Restore to Inbox', async () => {
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
     await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
+      expect(mockRouterPush).toHaveBeenCalledWith('/trash/test%40example.com');
     });
-    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
+  });
+
+  test('shows success toast after Restore to Inbox', async () => {
+    const user = userEvent.setup();
+    render(<MessageDetail message={BASE_MSG} />);
+    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('Moved to Inbox');
+    });
   });
 });
 
 describe('MessageDetail — junk folder', () => {
   beforeEach(() => {
-    global.fetch = jest.fn();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
     mockPathname.mockReturnValue('/junk/test%40example.com/msg-1');
   });
 
@@ -382,34 +371,19 @@ describe('MessageDetail — junk folder', () => {
   });
 
   test('calls PATCH with folder=inbox on Restore to Inbox click', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        '/api/messages/msg-1',
+        expect.stringContaining('/api/messages/msg-1'),
         expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ folder: 'inbox' }) }),
       );
     });
   });
 
-  test('dispatches hermes:messageremoved after Restore to Inbox', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) });
-    const events: CustomEvent[] = [];
-    window.addEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
-    const user = userEvent.setup();
-    render(<MessageDetail message={BASE_MSG} />);
-    await user.click(screen.getByRole('button', { name: /restore to inbox/i }));
-    await waitFor(() => {
-      expect(events.length).toBeGreaterThan(0);
-      expect(events[0].detail).toEqual({ messageId: 'msg-1' });
-    });
-    window.removeEventListener('hermes:messageremoved', (e) => events.push(e as CustomEvent));
-  });
-
   test('calls toast.error when Restore to Inbox fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
     const user = userEvent.setup();
     render(<MessageDetail message={BASE_MSG} />);
     await user.click(screen.getByRole('button', { name: /restore to inbox/i }));

--- a/app/__tests__/components/messages/reply-composer.test.tsx
+++ b/app/__tests__/components/messages/reply-composer.test.tsx
@@ -7,6 +7,14 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/',
 }));
 
+const mockReplyToMessageFn = jest.fn();
+const mockSendEmailFn = jest.fn();
+
+jest.mock('@/store/api', () => ({
+  useReplyToMessageMutation: jest.fn(() => [mockReplyToMessageFn]),
+  useSendEmailMutation: jest.fn(() => [mockSendEmailFn]),
+}));
+
 const BASE_MESSAGE = {
   messageId: 'msg-1',
   subject: 'Hello there',
@@ -24,6 +32,26 @@ const DEFAULT_PROPS = {
 
 beforeEach(() => {
   global.fetch = jest.fn();
+
+  mockReplyToMessageFn.mockImplementation(async ({ messageId, payload }: { messageId: string; payload: Record<string, unknown> }) => {
+    const res = await (global.fetch as jest.Mock)(
+      `/api/messages/${encodeURIComponent(messageId)}/reply`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    );
+    if (!(res as { ok: boolean }).ok) {
+      const data = await (res as { json: () => Promise<unknown> }).json();
+      return { error: { data } };
+    }
+    return { data: await (res as { json: () => Promise<unknown> }).json() };
+  });
+
+  mockSendEmailFn.mockImplementation(async (payload: Record<string, unknown>) => {
+    const res = await (global.fetch as jest.Mock)(
+      '/api/messages',
+      { method: 'POST', body: JSON.stringify(payload) },
+    );
+    return (res as { ok: boolean }).ok ? { data: {} } : { error: {} };
+  });
 });
 
 afterEach(() => {

--- a/app/__tests__/store/store.test.ts
+++ b/app/__tests__/store/store.test.ts
@@ -38,4 +38,89 @@ describe('apiSlice', () => {
   it('exposes sendEmail mutation endpoint', () => {
     expect(apiSlice.endpoints.sendEmail).toBeDefined();
   });
+
+  it('exposes getMessages query endpoint', () => {
+    expect(apiSlice.endpoints.getMessages).toBeDefined();
+  });
+
+  it('exposes getMessage query endpoint', () => {
+    expect(apiSlice.endpoints.getMessage).toBeDefined();
+  });
+
+  it('exposes markReadStatus mutation endpoint', () => {
+    expect(apiSlice.endpoints.markReadStatus).toBeDefined();
+  });
+
+  it('exposes moveMessage mutation endpoint', () => {
+    expect(apiSlice.endpoints.moveMessage).toBeDefined();
+  });
+
+  it('exposes deleteMessage mutation endpoint', () => {
+    expect(apiSlice.endpoints.deleteMessage).toBeDefined();
+  });
+
+  it('exposes replyToMessage mutation endpoint', () => {
+    expect(apiSlice.endpoints.replyToMessage).toBeDefined();
+  });
+});
+
+describe('apiSlice — getMessages cache key serialization', () => {
+  it('stores getMessages data by address+folder combination', () => {
+    const store = makeStore();
+    store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'inbox', direction: 'inbound' },
+        { messages: [], nextCursor: null },
+      ),
+    );
+    const state = store.getState();
+    expect(state[apiSlice.reducerPath]).toBeDefined();
+  });
+});
+
+describe('apiSlice — markReadStatus optimistic update', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it('updates isRead in the getMessages cache via onQueryStarted', async () => {
+    const store = makeStore();
+    const messages = [
+      { messageId: 'msg-1', subject: 'Hello', receivedAt: '2026-01-01T10:00:00Z', isRead: false, address: 'test@example.com' },
+    ];
+    store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', direction: 'inbound' },
+        { messages, nextCursor: null },
+      ),
+    );
+
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ message: { ...messages[0], isRead: true } }) });
+
+    const result = store.dispatch(
+      apiSlice.endpoints.markReadStatus.initiate({
+        messageId: 'msg-1',
+        isRead: true,
+        address: 'test@example.com',
+        direction: 'inbound',
+      }),
+    );
+
+    // Optimistic update should be applied immediately
+    const cacheData = (store.getState() as ReturnType<typeof store['getState']>)[apiSlice.reducerPath];
+    expect(cacheData).toBeDefined();
+
+    await result;
+  });
+});
+
+describe('apiSlice — deleteMessage optimistic update', () => {
+  it('exposes deleteMessage endpoint with onQueryStarted optimistic update', () => {
+    // The endpoint exists and has the correct structure.
+    // Optimistic update behavior is verified in message-list.test.tsx via mock mutations.
+    expect(apiSlice.endpoints.deleteMessage).toBeDefined();
+    expect(typeof apiSlice.endpoints.deleteMessage.initiate).toBe('function');
+  });
 });

--- a/app/components/inbox/message-list.tsx
+++ b/app/components/inbox/message-list.tsx
@@ -2,30 +2,22 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { useDispatch } from 'react-redux';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useWs } from '@/components/ws-context';
 import { MailboxCard, formatMailboxDate } from '@/components/mailbox-card';
 import { BulkActionToolbar } from '@/components/bulk-action-toolbar';
-
-interface Attachment {
-  filename: string;
-  s3Key: string;
-}
-
-interface Message {
-  messageId: string;
-  address: string;
-  sender?: string;
-  from?: string;
-  to?: string;
-  direction?: 'inbound' | 'outbound';
-  subject: string;
-  receivedAt: string;
-  isRead: boolean;
-  snippet?: string;
-  attachments?: Attachment[];
-}
+import {
+  useGetMessagesQuery,
+  useLazyGetMessagesQuery,
+  useMarkReadStatusMutation,
+  useMoveMessageMutation,
+  useDeleteMessageMutation,
+  apiSlice,
+  type Message,
+} from '@/store/api';
+import type { AppDispatch } from '@/store';
 
 interface MessageListProps {
   address: string;
@@ -41,15 +33,25 @@ type Filter = 'all' | 'unread';
 export function MessageList({ address, direction, folder, initialMessages, initialNextCursor, folderLabel }: MessageListProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const dispatch = useDispatch<AppDispatch>();
   const { subscribe } = useWs();
-  const [messages, setMessages] = useState<Message[]>(initialMessages);
-  const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
+
+  const { data, isFetching } = useGetMessagesQuery({ address, folder, direction });
+  const [triggerLoadMore, { isFetching: isLoadingMore }] = useLazyGetMessagesQuery();
+  const [markReadStatus] = useMarkReadStatusMutation();
+  const [moveMessage] = useMoveMessageMutation();
+  const [deleteMessage] = useDeleteMessageMutation();
+
+  const messages = data?.messages ?? initialMessages;
+  const nextCursor = data?.nextCursor ?? initialNextCursor;
+  const isLoading = (isFetching || isLoadingMore) && !data;
+
   const [filter, setFilter] = useState<Filter>('all');
-  const [isLoading, setIsLoading] = useState(false);
   const [pendingMessageId, setPendingMessageId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const isInboxFolder = folder === 'inbox' || (!folder && direction === 'inbound');
+  const isSent = direction === 'outbound';
 
   const activeMessageId = (() => {
     const segments = pathname.split('/');
@@ -60,88 +62,54 @@ export function MessageList({ address, direction, folder, initialMessages, initi
     setPendingMessageId(null);
   }, [pathname]);
 
-  // Clear selection when navigating between folders
   useEffect(() => {
     setSelectedIds(new Set());
   }, [folder, direction]);
 
+  // Prepend incoming WS messages directly into the RTK cache
   useEffect(() => {
     if (!isInboxFolder) return;
     return subscribe((event) => {
       if (event.address.toLowerCase() !== address.toLowerCase()) return;
       fetch(`/api/messages/${encodeURIComponent(event.messageId)}`)
         .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          const incoming: Message = data?.message;
+        .then((responseData) => {
+          const incoming: Message = responseData?.message;
           if (!incoming) return;
-          setMessages((prev) => {
-            if (prev.some((m) => m.messageId === incoming.messageId)) return prev;
-            return [incoming, ...prev];
-          });
+          dispatch(
+            apiSlice.util.updateQueryData(
+              'getMessages',
+              { address, folder, direction },
+              (draft) => {
+                if (draft.messages.some((m) => m.messageId === incoming.messageId)) return;
+                draft.messages.unshift(incoming);
+              },
+            ),
+          );
         })
         .catch(() => null);
     });
-  }, [subscribe, address, isInboxFolder]);
+  }, [subscribe, address, isInboxFolder, dispatch, folder, direction]);
 
-  useEffect(() => {
-    function onReadStatus(e: Event) {
-      const { messageId, isRead } = (e as CustomEvent<{ messageId: string; isRead: boolean }>).detail;
-      setMessages((prev) =>
-        prev.map((m) => m.messageId === messageId ? { ...m, isRead } : m),
-      );
+  function handleLoadMore() {
+    if (nextCursor) {
+      triggerLoadMore({ address, folder, direction, cursor: nextCursor });
     }
-    window.addEventListener('hermes:readstatus', onReadStatus);
-    return () => window.removeEventListener('hermes:readstatus', onReadStatus);
-  }, []);
-
-  useEffect(() => {
-    function onMessageRemoved(e: Event) {
-      const { messageId } = (e as CustomEvent<{ messageId: string }>).detail;
-      setMessages((prev) => prev.filter((m) => m.messageId !== messageId));
-    }
-    window.addEventListener('hermes:messageremoved', onMessageRemoved);
-    return () => window.removeEventListener('hermes:messageremoved', onMessageRemoved);
-  }, []);
-
-  useEffect(() => {
-    if (!isInboxFolder) return;
-    const unreadCount = messages.filter((m) => !m.isRead).length;
-    window.dispatchEvent(
-      new CustomEvent('hermes:inboxcount', { detail: { address, unreadCount } }),
-    );
-  }, [messages, address, isInboxFolder]);
-
-  const fetchMessages = useCallback(async (cursor?: string) => {
-    setIsLoading(true);
-    const params = new URLSearchParams({ address });
-    if (folder) {
-      params.set('folder', folder);
-    } else {
-      params.set('direction', direction);
-    }
-    if (cursor) params.set('cursor', cursor);
-
-    try {
-      const res = await fetch(`/api/messages?${params.toString()}`);
-      if (!res.ok) return;
-      const data = await res.json();
-      if (cursor) {
-        setMessages((prev) => [...prev, ...(data.messages ?? [])]);
-      } else {
-        setMessages(data.messages ?? []);
-      }
-      setNextCursor(data.nextCursor ?? null);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [address, direction, folder]);
+  }
 
   function handleRowClick(msg: Message) {
     setPendingMessageId(msg.messageId);
     const root = folder ?? (direction === 'outbound' ? 'sent' : 'inbox');
-    if (!isSent && !msg.isRead && (folder === 'inbox' || folder === 'junk' || !folder)) {
-      setMessages((prev) =>
-        prev.map((m) => m.messageId === msg.messageId ? { ...m, isRead: true } : m),
+    if (!isSent && !msg.isRead && isInboxFolder) {
+      dispatch(
+        apiSlice.util.updateQueryData(
+          'getMessages',
+          { address, folder, direction },
+          (draft) => {
+            const m = draft.messages.find((m) => m.messageId === msg.messageId);
+            if (m) m.isRead = true;
+          },
+        ),
       );
     }
     router.push(`/${root}/${encodeURIComponent(address)}/${msg.messageId}`);
@@ -176,139 +144,63 @@ export function MessageList({ address, direction, folder, initialMessages, initi
 
   async function handleBulkDelete() {
     const ids = [...selectedIds];
-    const removed = messages.filter((m) => ids.includes(m.messageId));
-    setMessages((prev) => prev.filter((m) => !selectedIds.has(m.messageId)));
     setSelectedIds(new Set());
     navigateAwayIfNeeded(ids);
 
-    const results = await Promise.allSettled(
+    await Promise.allSettled(
       ids.map((id) =>
         folder === 'trash'
-          ? fetch(`/api/messages/${encodeURIComponent(id)}`, { method: 'DELETE' })
-          : fetch(`/api/messages/${encodeURIComponent(id)}`, {
-              method: 'PATCH',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ folder: 'trash' }),
+          ? deleteMessage({ messageId: id, address, folder, direction })
+          : moveMessage({
+              messageId: id,
+              targetFolder: 'trash',
+              fromAddress: address,
+              fromFolder: folder,
+              fromDirection: direction,
             }),
       ),
     );
-
-    const failed = removed.filter((_, i) => {
-      const r = results[i];
-      return r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.ok);
-    });
-    if (failed.length > 0) {
-      setMessages((prev) => {
-        const existing = new Set(prev.map((m) => m.messageId));
-        return [...failed.filter((m) => !existing.has(m.messageId)), ...prev];
-      });
-    }
-    router.refresh();
   }
 
   async function handleBulkJunk() {
     const ids = [...selectedIds];
-    const removed = messages.filter((m) => ids.includes(m.messageId));
-    setMessages((prev) => prev.filter((m) => !selectedIds.has(m.messageId)));
     setSelectedIds(new Set());
     navigateAwayIfNeeded(ids);
 
-    const results = await Promise.allSettled(
+    await Promise.allSettled(
       ids.map((id) =>
-        fetch(`/api/messages/${encodeURIComponent(id)}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ folder: 'junk' }),
+        moveMessage({
+          messageId: id,
+          targetFolder: 'junk',
+          fromAddress: address,
+          fromFolder: folder,
+          fromDirection: direction,
         }),
       ),
     );
-
-    const failed = removed.filter((_, i) => {
-      const r = results[i];
-      return r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.ok);
-    });
-    if (failed.length > 0) {
-      setMessages((prev) => {
-        const existing = new Set(prev.map((m) => m.messageId));
-        return [...failed.filter((m) => !existing.has(m.messageId)), ...prev];
-      });
-    }
-    router.refresh();
   }
 
   async function handleBulkMarkRead() {
     const ids = [...selectedIds];
-    const original = messages.map((m) => ({ id: m.messageId, isRead: m.isRead }));
-    setMessages((prev) =>
-      prev.map((m) => selectedIds.has(m.messageId) ? { ...m, isRead: true } : m),
-    );
     setSelectedIds(new Set());
 
-    const results = await Promise.allSettled(
+    await Promise.allSettled(
       ids.map((id) =>
-        fetch(`/api/messages/${encodeURIComponent(id)}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ isRead: true }),
-        }),
+        markReadStatus({ messageId: id, isRead: true, address, folder, direction }),
       ),
     );
-
-    const failedIds = new Set(
-      ids.filter((_, i) => {
-        const r = results[i];
-        return r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.ok);
-      }),
-    );
-    if (failedIds.size > 0) {
-      setMessages((prev) =>
-        prev.map((m) => {
-          if (!failedIds.has(m.messageId)) return m;
-          const orig = original.find((o) => o.id === m.messageId);
-          return orig ? { ...m, isRead: orig.isRead } : m;
-        }),
-      );
-    }
-    router.refresh();
   }
 
   async function handleBulkMarkUnread() {
     const ids = [...selectedIds];
-    const original = messages.map((m) => ({ id: m.messageId, isRead: m.isRead }));
-    setMessages((prev) =>
-      prev.map((m) => selectedIds.has(m.messageId) ? { ...m, isRead: false } : m),
-    );
     setSelectedIds(new Set());
 
-    const results = await Promise.allSettled(
+    await Promise.allSettled(
       ids.map((id) =>
-        fetch(`/api/messages/${encodeURIComponent(id)}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ isRead: false }),
-        }),
+        markReadStatus({ messageId: id, isRead: false, address, folder, direction }),
       ),
     );
-
-    const failedIds = new Set(
-      ids.filter((_, i) => {
-        const r = results[i];
-        return r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.ok);
-      }),
-    );
-    if (failedIds.size > 0) {
-      setMessages((prev) =>
-        prev.map((m) => {
-          if (!failedIds.has(m.messageId)) return m;
-          const orig = original.find((o) => o.id === m.messageId);
-          return orig ? { ...m, isRead: orig.isRead } : m;
-        }),
-      );
-    }
-    router.refresh();
   }
-
-  const isSent = direction === 'outbound';
 
   function extractDisplayName(emailStr: string): string {
     const match = emailStr.match(/^(.+?)\s*<[^>]+>$/);
@@ -405,8 +297,8 @@ export function MessageList({ address, direction, folder, initialMessages, initi
             </div>
             {nextCursor && (
               <div className="flex justify-center py-3">
-                <Button variant="ghost" size="sm" onClick={() => fetchMessages(nextCursor)} disabled={isLoading}>
-                  {isLoading ? 'Loading…' : 'Load more'}
+                <Button variant="ghost" size="sm" onClick={handleLoadMore} disabled={isLoadingMore}>
+                  {isLoadingMore ? 'Loading…' : 'Load more'}
                 </Button>
               </div>
             )}

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@
 import Link, { useLinkStatus } from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useGetMessagesQuery } from "@/store/api";
 import {
   Sidebar,
   SidebarContent,
@@ -114,7 +115,7 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
     return map;
   });
 
-  // Increment from WS events (best-effort; overridden by hermes:inboxcount when inbox is open)
+  // Increment from WS events (best-effort; overridden by RTK Query cache when inbox is open)
   useEffect(() => {
     return subscribe((event) => {
       setUnreadCounts((prev) => {
@@ -125,19 +126,21 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
     });
   }, [subscribe]);
 
-  // Accurate count broadcast by MessageList on mount and on every local state change
+  // Derive accurate inbox unread count from RTK Query cache for the selected address
+  const { data: selectedInboxData } = useGetMessagesQuery(
+    { address: selectedAddress ?? '', folder: 'inbox', direction: 'inbound' },
+    { skip: !selectedAddress },
+  );
+
   useEffect(() => {
-    function onInboxCount(e: Event) {
-      const { address: addr, unreadCount } = (e as CustomEvent<{ address: string; unreadCount: number }>).detail;
-      setUnreadCounts((prev) => {
-        const next = new Map(prev);
-        next.set(addr, unreadCount);
-        return next;
-      });
-    }
-    window.addEventListener('hermes:inboxcount', onInboxCount);
-    return () => window.removeEventListener('hermes:inboxcount', onInboxCount);
-  }, []);
+    if (!selectedAddress || !selectedInboxData) return;
+    const count = selectedInboxData.messages.filter((m) => !m.isRead).length;
+    setUnreadCounts((prev) => {
+      const next = new Map(prev);
+      next.set(selectedAddress, count);
+      return next;
+    });
+  }, [selectedInboxData, selectedAddress]);
 
   async function handleCompose() {
     if (!selectedAddress || isComposing || isOnDraftDetailRoute) return;

--- a/app/components/messages/message-detail.tsx
+++ b/app/components/messages/message-detail.tsx
@@ -19,6 +19,11 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ReplyComposer } from '@/components/messages/reply-composer';
+import {
+  useMarkReadStatusMutation,
+  useMoveMessageMutation,
+  useDeleteMessageMutation,
+} from '@/store/api';
 
 interface Attachment {
   filename: string;
@@ -60,6 +65,17 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   const showReadToggle = folder === 'inbox' || folder === 'junk';
   const listHref = pathname.split('/').slice(0, 3).join('/');
 
+  // Derive the cache context from the current route
+  const fromFolder = (folder === 'inbox' || folder === 'junk' || folder === 'trash')
+    ? (folder as 'inbox' | 'junk' | 'trash')
+    : undefined;
+  const fromDirection = (!fromFolder && !isSent) ? 'inbound' : (isSent ? 'outbound' : undefined);
+  const fromAddress = message.address ?? (isSent ? message.from : message.to) ?? '';
+
+  const [markReadStatus] = useMarkReadStatusMutation();
+  const [moveMessage] = useMoveMessageMutation();
+  const [deleteMsg] = useDeleteMessageMutation();
+
   const [htmlBody] = useState<string | null>(initialHtmlBody ?? null);
   const [textBody] = useState<string | null>(initialTextBody ?? null);
   const [isRead, setIsRead] = useState(message.isRead);
@@ -69,25 +85,17 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   const [isMovingToJunk, setIsMovingToJunk] = useState(false);
   const [isTogglingRead, setIsTogglingRead] = useState(false);
 
-  function dispatchReadEvent(messageId: string, isRead: boolean) {
-    window.dispatchEvent(new CustomEvent('hermes:readstatus', { detail: { messageId, isRead } }));
-  }
-
+  // Auto-mark as read when opening an unread message in inbox or junk
   useEffect(() => {
     if (!showReadToggle || message.isRead) return;
-    fetch(`/api/messages/${message.messageId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ isRead: true }),
-    }).then((r) => {
-      if (r.ok) {
-        setIsRead(true);
-        dispatchReadEvent(message.messageId, true);
-        // Bust the Next.js Router Cache so navigating back to the inbox
-        // re-fetches from the server and reflects the updated isRead state.
-        router.refresh();
-      }
-    }).catch(() => null);
+    setIsRead(true);
+    markReadStatus({
+      messageId: message.messageId,
+      isRead: true,
+      address: fromAddress,
+      folder: fromFolder,
+      direction: fromDirection,
+    });
   }, [message.messageId, message.isRead, showReadToggle]);
 
   async function toggleRead() {
@@ -95,12 +103,13 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
     setIsRead(next);
     setIsTogglingRead(true);
     try {
-      await fetch(`/api/messages/${message.messageId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isRead: next }),
+      await markReadStatus({
+        messageId: message.messageId,
+        isRead: next,
+        address: fromAddress,
+        folder: fromFolder,
+        direction: fromDirection,
       });
-      dispatchReadEvent(message.messageId, next);
     } catch {
       setIsRead(!next);
     } finally {
@@ -111,19 +120,19 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   async function handleMoveToTrash() {
     setIsDeleting(true);
     try {
-      const res = await fetch(`/api/messages/${message.messageId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ folder: 'trash' }),
+      const result = await moveMessage({
+        messageId: message.messageId,
+        targetFolder: 'trash',
+        fromAddress,
+        fromFolder,
+        fromDirection,
       });
-      if (!res.ok) {
+      if ('error' in result) {
         toast.error('Failed to move message to Trash');
         return;
       }
-      dispatchMessageRemoved(message.messageId);
       toast.success('Moved to Trash');
       router.push(listHref);
-      router.refresh();
     } catch {
       toast.error('Failed to move message to Trash');
     } finally {
@@ -134,14 +143,17 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   async function handleDelete() {
     setIsDeleting(true);
     try {
-      const res = await fetch(`/api/messages/${message.messageId}`, { method: 'DELETE' });
-      if (!res.ok) {
+      const result = await deleteMsg({
+        messageId: message.messageId,
+        address: fromAddress,
+        folder: fromFolder,
+        direction: fromDirection,
+      });
+      if ('error' in result) {
         toast.error('Failed to delete message');
         return;
       }
-      dispatchMessageRemoved(message.messageId);
       router.push(listHref);
-      router.refresh();
     } catch {
       toast.error('Failed to delete message');
     } finally {
@@ -149,26 +161,22 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
     }
   }
 
-  function dispatchMessageRemoved(messageId: string) {
-    window.dispatchEvent(new CustomEvent('hermes:messageremoved', { detail: { messageId } }));
-  }
-
   async function handleRestoreToInbox() {
     setIsRestoring(true);
     try {
-      const res = await fetch(`/api/messages/${message.messageId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ folder: 'inbox' }),
+      const result = await moveMessage({
+        messageId: message.messageId,
+        targetFolder: 'inbox',
+        fromAddress,
+        fromFolder,
+        fromDirection,
       });
-      if (!res.ok) {
+      if ('error' in result) {
         toast.error('Failed to restore message');
         return;
       }
-      dispatchMessageRemoved(message.messageId);
       toast.success('Moved to Inbox');
       router.push(listHref);
-      router.refresh();
     } catch {
       toast.error('Failed to restore message');
     } finally {
@@ -179,19 +187,19 @@ export function MessageDetail({ message, initialHtmlBody, initialTextBody, initi
   async function handleMoveToJunk() {
     setIsMovingToJunk(true);
     try {
-      const res = await fetch(`/api/messages/${message.messageId}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ folder: 'junk' }),
+      const result = await moveMessage({
+        messageId: message.messageId,
+        targetFolder: 'junk',
+        fromAddress,
+        fromFolder,
+        fromDirection,
       });
-      if (!res.ok) {
+      if ('error' in result) {
         toast.error('Failed to move message to Junk');
         return;
       }
-      dispatchMessageRemoved(message.messageId);
       toast.success('Moved to Junk');
       router.push(listHref);
-      router.refresh();
     } catch {
       toast.error('Failed to move message to Junk');
     } finally {

--- a/app/components/messages/reply-composer.tsx
+++ b/app/components/messages/reply-composer.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { BookMarked, Paperclip, Send, Trash2, X } from 'lucide-react';
+import { useReplyToMessageMutation, useSendEmailMutation } from '@/store/api';
 
 interface Message {
   messageId: string;
@@ -59,6 +60,9 @@ export function ReplyComposer({
   onClose,
 }: ReplyComposerProps) {
   const router = useRouter();
+  const [replyToMessage] = useReplyToMessageMutation();
+  const [sendEmail] = useSendEmailMutation();
+
   const originalSubject = message.subject ?? '';
 
   const defaultSubject = (() => {
@@ -176,41 +180,38 @@ export function ReplyComposer({
     setIsSending(true);
     setSendError(null);
     try {
-      const endpoint = mode === 'forward'
-        ? '/api/messages'
-        : `/api/messages/${message.messageId}/reply`;
-      const method = 'POST';
-      const bodyPayload = mode === 'forward'
-        ? {
+      let result;
+      if (mode === 'forward') {
+        result = await sendEmail({
+          from: currentAddress,
+          to,
+          cc: cc || undefined,
+          subject: defaultSubject,
+          body,
+          attachmentKeys: attachments.map((a) => a.s3Key),
+          draftId: draftId ?? undefined,
+        });
+      } else {
+        result = await replyToMessage({
+          messageId: message.messageId,
+          payload: {
             from: currentAddress,
             to,
             cc: cc || undefined,
-            subject: defaultSubject,
             body,
             attachmentKeys: attachments.map((a) => a.s3Key),
             draftId: draftId ?? undefined,
-          }
-        : {
-            from: currentAddress,
-            to,
-            cc: cc || undefined,
-            body,
-            attachmentKeys: attachments.map((a) => a.s3Key),
-            draftId: draftId ?? undefined,
-          };
+          },
+        });
+      }
 
-      const res = await fetch(endpoint, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(bodyPayload),
-      });
-      if (!res.ok) {
-        const data = await res.json() as { error?: string };
-        setSendError(data.error ?? 'Failed to send');
+      if ('error' in result) {
+        const errData = result.error as { data?: { error?: string } };
+        setSendError(errData?.data?.error ?? 'Failed to send');
         return;
       }
+
       onClose();
-      router.refresh();
     } catch {
       setSendError('Failed to send. Please try again.');
     } finally {

--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -1,1 +1,26 @@
 import '@testing-library/jest-dom';
+
+// RTK Query's fetchBaseQuery creates `new Request(...)` internally.
+// jsdom does not provide the WHATWG Fetch API globals. Use Next.js's bundled
+// @edge-runtime/primitives to supply Request, Response, and Headers.
+if (typeof Request === 'undefined') {
+  // Edge-runtime fetch depends on several Web API globals that jsdom may lack.
+  // Supply them from Node.js built-ins before loading the fetch module.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const util = require('node:util');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const stream = require('node:stream/web');
+  const missing: Record<string, unknown> = {};
+  if (typeof TextEncoder === 'undefined') missing.TextEncoder = util.TextEncoder;
+  if (typeof TextDecoder === 'undefined') missing.TextDecoder = util.TextDecoder;
+  if (typeof ReadableStream === 'undefined') missing.ReadableStream = stream.ReadableStream;
+  if (typeof WritableStream === 'undefined') missing.WritableStream = stream.WritableStream;
+  if (typeof TransformStream === 'undefined') missing.TransformStream = stream.TransformStream;
+  if (Object.keys(missing).length) Object.assign(global, missing);
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Request: Req, Response: Res, Headers: Hdrs } = require(
+    'next/dist/compiled/@edge-runtime/primitives/fetch.js'
+  );
+  Object.assign(global, { Request: Req, Response: Res, Headers: Hdrs });
+}

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -30,6 +30,77 @@ export interface SendEmailPayload {
   draftId?: string;
 }
 
+export interface Message {
+  messageId: string;
+  address?: string;
+  sender?: string;
+  from?: string;
+  to?: string;
+  direction?: 'inbound' | 'outbound';
+  subject: string;
+  receivedAt: string;
+  isRead: boolean;
+  snippet?: string;
+  folder?: string;
+  attachments?: Array<{
+    filename: string;
+    s3Key?: string;
+    url?: string;
+    contentType?: string;
+    size?: number;
+  }>;
+}
+
+export interface GetMessagesResponse {
+  messages: Message[];
+  nextCursor: string | null;
+}
+
+export interface GetMessagesArgs {
+  address: string;
+  folder?: string;
+  direction?: string;
+  cursor?: string;
+}
+
+export interface MarkReadStatusArgs {
+  messageId: string;
+  isRead: boolean;
+  address: string;
+  folder?: string;
+  direction?: string;
+}
+
+export interface MoveMessageArgs {
+  messageId: string;
+  targetFolder: string;
+  fromAddress: string;
+  fromFolder?: string;
+  fromDirection?: string;
+}
+
+export interface DeleteMessageArgs {
+  messageId: string;
+  address: string;
+  folder?: string;
+  direction?: string;
+}
+
+export interface ReplyPayload {
+  from: string;
+  to: string;
+  cc?: string;
+  body: string;
+  subject?: string;
+  attachmentKeys?: string[];
+  draftId?: string;
+}
+
+export interface ReplyToMessageArgs {
+  messageId: string;
+  payload: ReplyPayload;
+}
+
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
@@ -60,7 +131,135 @@ export const apiSlice = createApi({
       },
       invalidatesTags: (_result, error) => (error ? [] : ['Draft']),
     }),
+    getMessages: builder.query<GetMessagesResponse, GetMessagesArgs>({
+      query: ({ address, folder, direction, cursor }) => {
+        const params = new URLSearchParams({ address });
+        if (folder) params.set('folder', folder);
+        else if (direction) params.set('direction', direction);
+        if (cursor) params.set('cursor', cursor);
+        return `/messages?${params.toString()}`;
+      },
+      providesTags: (result, _err, { address, folder, direction }) => [
+        { type: 'Folder' as const, id: `${address}-${folder ?? direction ?? 'all'}` },
+        ...(result?.messages.map((m) => ({ type: 'Message' as const, id: m.messageId })) ?? []),
+      ],
+      serializeQueryArgs: ({ queryArgs: { address, folder, direction } }) =>
+        JSON.stringify({ address, folder, direction }),
+      merge: (currentCache, newItems, { arg }) => {
+        if (arg.cursor) {
+          currentCache.messages.push(...newItems.messages);
+          currentCache.nextCursor = newItems.nextCursor;
+        } else {
+          return newItems;
+        }
+      },
+      forceRefetch: ({ currentArg, previousArg }) =>
+        currentArg?.cursor !== previousArg?.cursor,
+    }),
+    getMessage: builder.query<{ message: Message }, string>({
+      query: (id) => `/messages/${encodeURIComponent(id)}`,
+      providesTags: (_res, _err, id) => [{ type: 'Message' as const, id }],
+    }),
+    markReadStatus: builder.mutation<{ message: Message }, MarkReadStatusArgs>({
+      query: ({ messageId, isRead }) => ({
+        url: `/messages/${encodeURIComponent(messageId)}`,
+        method: 'PATCH',
+        body: { isRead },
+      }),
+      async onQueryStarted(
+        { messageId, isRead, address, folder, direction },
+        { dispatch, queryFulfilled },
+      ) {
+        const patch = dispatch(
+          apiSlice.util.updateQueryData(
+            'getMessages',
+            { address, folder, direction },
+            (draft) => {
+              const msg = draft.messages.find((m) => m.messageId === messageId);
+              if (msg) msg.isRead = isRead;
+            },
+          ),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patch.undo();
+        }
+      },
+    }),
+    moveMessage: builder.mutation<{ message: Message }, MoveMessageArgs>({
+      query: ({ messageId, targetFolder }) => ({
+        url: `/messages/${encodeURIComponent(messageId)}`,
+        method: 'PATCH',
+        body: { folder: targetFolder },
+      }),
+      async onQueryStarted(
+        { messageId, fromAddress, fromFolder, fromDirection },
+        { dispatch, queryFulfilled },
+      ) {
+        const patch = dispatch(
+          apiSlice.util.updateQueryData(
+            'getMessages',
+            { address: fromAddress, folder: fromFolder, direction: fromDirection },
+            (draft) => {
+              draft.messages = draft.messages.filter((m) => m.messageId !== messageId);
+            },
+          ),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patch.undo();
+        }
+      },
+      invalidatesTags: (_result, error, { targetFolder, fromAddress }) =>
+        error ? [] : [{ type: 'Folder' as const, id: `${fromAddress}-${targetFolder}` }],
+    }),
+    deleteMessage: builder.mutation<{ success: boolean }, DeleteMessageArgs>({
+      query: ({ messageId }) => ({
+        url: `/messages/${encodeURIComponent(messageId)}`,
+        method: 'DELETE',
+      }),
+      async onQueryStarted(
+        { messageId, address, folder, direction },
+        { dispatch, queryFulfilled },
+      ) {
+        const patch = dispatch(
+          apiSlice.util.updateQueryData(
+            'getMessages',
+            { address, folder, direction },
+            (draft) => {
+              draft.messages = draft.messages.filter((m) => m.messageId !== messageId);
+            },
+          ),
+        );
+        try {
+          await queryFulfilled;
+        } catch {
+          patch.undo();
+        }
+      },
+    }),
+    replyToMessage: builder.mutation<{ messageId: string }, ReplyToMessageArgs>({
+      query: ({ messageId, payload }) => ({
+        url: `/messages/${encodeURIComponent(messageId)}/reply`,
+        method: 'POST',
+        body: payload,
+      }),
+      invalidatesTags: (_result, error, { payload }) =>
+        error ? [] : [{ type: 'Folder' as const, id: `${payload.from}-outbound` }],
+    }),
   }),
 });
 
-export const { useGetDraftsQuery, useSendEmailMutation } = apiSlice;
+export const {
+  useGetDraftsQuery,
+  useSendEmailMutation,
+  useGetMessagesQuery,
+  useLazyGetMessagesQuery,
+  useGetMessageQuery,
+  useMarkReadStatusMutation,
+  useMoveMessageMutation,
+  useDeleteMessageMutation,
+  useReplyToMessageMutation,
+} = apiSlice;


### PR DESCRIPTION
…ystem (#219)

Extends apiSlice with getMessages, getMessage, markReadStatus, moveMessage, deleteMessage, and replyToMessage endpoints using RTK Query with optimistic updates via onQueryStarted. Refactors MessageList, MessageDetail, ReplyComposer, and Sidebar to consume RTK hooks exclusively, removing all custom hermes:* events and router.refresh() calls. Updates test infrastructure to use module-level mock pattern (following drafts-list.test.tsx precedent) with stateful mock hooks and deep-copy fixture resets to prevent cross-test mutation of shared objects.

closes #219