### PR TITLE
[fix]: count only inbox unread in address badge, remove first-page co…

### DIFF
--- a/app/__tests__/app/api/addresses/route.test.ts
+++ b/app/__tests__/app/api/addresses/route.test.ts
@@ -103,6 +103,23 @@ describe('GET /api/addresses', () => {
     expect(body).toEqual({ addresses: [] });
   });
 
+  test('unread count query filters to inbox folder only', async () => {
+    mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
+    setupGetMock([{ email: 'hello@example.com', domain: 'example.com', status: 'active' }], 5);
+
+    await GET(makeGetReq());
+
+    const queryArg = (mockDynamoSend.mock.calls as [Record<string, unknown>][])
+      .map(([cmd]) => cmd)
+      .find((cmd) => cmd.IndexName !== undefined);
+
+    expect(queryArg).toMatchObject({
+      FilterExpression: expect.stringContaining('attribute_not_exists(#folder)'),
+      ExpressionAttributeNames: expect.objectContaining({ '#folder': 'folder' }),
+      ExpressionAttributeValues: expect.objectContaining({ ':inbox': 'inbox' }),
+    });
+  });
+
   test('filters out soft-deleted addresses via FilterExpression', async () => {
     mockRequireAuth.mockResolvedValue({ sub: 'user-1' });
     setupGetMock([]);

--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -52,17 +52,13 @@ jest.mock('react-redux', () => ({
 
 const mockSidebarInvalidateTags = jest.fn(() => ({ type: 'test/invalidate' }));
 
-// Mock RTK Query hook — sidebar uses this to derive inbox unread count
 jest.mock('@/store/api', () => ({
-  useGetMessagesQuery: jest.fn(() => ({ data: null, isFetching: false })),
   apiSlice: {
     util: {
       invalidateTags: (...args: unknown[]) => mockSidebarInvalidateTags(...args),
     },
   },
 }));
-
-import { useGetMessagesQuery } from '@/store/api';
 
 const ADDRESSES = [
   { email: 'hello@example.com', domain: 'example.com', status: 'active', unreadCount: 3 },
@@ -101,7 +97,6 @@ beforeEach(() => {
   mockSidebarInvalidateTags.mockClear();
   wsHandler = null;
   mockSubscribe.mockClear();
-  (useGetMessagesQuery as jest.Mock).mockReturnValue({ data: null, isFetching: false });
 });
 
 afterEach(() => {
@@ -186,25 +181,6 @@ describe('AppSidebar', () => {
     mockPathname.mockReturnValue('/inbox/hello%40example.com');
     renderSidebar();
     expect(screen.getByText('3')).toBeInTheDocument();
-  });
-
-  test('updates unread badge when RTK Query inbox data is available', async () => {
-    mockPathname.mockReturnValue('/inbox/hello%40example.com');
-    (useGetMessagesQuery as jest.Mock).mockReturnValue({
-      data: {
-        messages: [
-          { messageId: 'msg-1', isRead: false },
-          { messageId: 'msg-2', isRead: false },
-          { messageId: 'msg-3', isRead: true },
-        ],
-        nextCursor: null,
-      },
-      isFetching: false,
-    });
-    renderSidebar();
-    await waitFor(() => {
-      expect(screen.getByText('2')).toBeInTheDocument();
-    });
   });
 
   test('increments unread badge when WebSocket new_message event arrives', async () => {

--- a/app/app/api/addresses/route.ts
+++ b/app/app/api/addresses/route.ts
@@ -41,8 +41,9 @@ export async function GET(req: NextRequest) {
           TableName: process.env.MESSAGES_TABLE!,
           IndexName: 'address-receivedAt-index',
           KeyConditionExpression: 'address = :addr',
-          FilterExpression: 'isRead = :false AND direction = :dir',
-          ExpressionAttributeValues: { ':addr': addr.email, ':false': false, ':dir': 'inbound' },
+          FilterExpression: 'isRead = :false AND direction = :dir AND (#folder = :inbox OR attribute_not_exists(#folder))',
+          ExpressionAttributeNames: { '#folder': 'folder' },
+          ExpressionAttributeValues: { ':addr': addr.email, ':false': false, ':dir': 'inbound', ':inbox': 'inbox' },
           Select: 'COUNT',
         }));
         return { ...addr, unreadCount: unread.Count ?? 0 };

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import type { AppDispatch } from "@/store";
-import { useGetMessagesQuery, apiSlice } from "@/store/api";
+import { apiSlice } from "@/store/api";
 import {
   Sidebar,
   SidebarContent,
@@ -129,21 +129,6 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
     });
   }, [subscribe]);
 
-  // Derive accurate inbox unread count from RTK Query cache for the selected address
-  const { data: selectedInboxData } = useGetMessagesQuery(
-    { address: selectedAddress ?? '', folder: 'inbox', direction: 'inbound' },
-    { skip: !selectedAddress },
-  );
-
-  useEffect(() => {
-    if (!selectedAddress || !selectedInboxData) return;
-    const count = selectedInboxData.messages.filter((m) => !m.isRead).length;
-    setUnreadCounts((prev) => {
-      const next = new Map(prev);
-      next.set(selectedAddress, count);
-      return next;
-    });
-  }, [selectedInboxData, selectedAddress]);
 
   async function handleCompose() {
     if (!selectedAddress || isComposing || isOnDraftDetailRoute) return;


### PR DESCRIPTION
…rrection (#231)

The unread badge oscillated between the server count and 0 because two sources of truth conflicted:
- /api/addresses counted unread across all folders (inbox + junk + trash)
- sidebar.tsx overrode the count using only the first-page RTK Query result

Fix the DynamoDB count query to filter to inbox messages only (folder = inbox OR attribute_not_exists(folder)) and remove the inaccurate first-page correction from the sidebar. The server count is now the single source of truth; WS increments on new messages are kept.

closes #231