### PR TITLE
[fix]: decrement unread badge in real time when messages are read or …

### DIFF
--- a/app/__tests__/components/layout/sidebar.test.tsx
+++ b/app/__tests__/components/layout/sidebar.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
 import { AppSidebar } from '@/components/layout/sidebar';
 import { SidebarProvider } from '@/components/ui/sidebar';
+import { makeStore } from '@/store';
+import { apiSlice } from '@/store/api';
 import type { WsNewMessageEvent } from '@/lib/ws';
 
 const mockPush = jest.fn();
@@ -45,35 +48,26 @@ jest.mock('@/components/ui/tooltip', () => ({
   TooltipContent: () => null,
 }));
 
-const mockSidebarDispatch = jest.fn((action) => action);
-jest.mock('react-redux', () => ({
-  useDispatch: () => mockSidebarDispatch,
-}));
-
-const mockSidebarInvalidateTags = jest.fn(() => ({ type: 'test/invalidate' }));
-
-jest.mock('@/store/api', () => ({
-  apiSlice: {
-    util: {
-      invalidateTags: (...args: unknown[]) => mockSidebarInvalidateTags(...args),
-    },
-  },
-}));
-
 const ADDRESSES = [
   { email: 'hello@example.com', domain: 'example.com', status: 'active', unreadCount: 3 },
   { email: 'info@example.com', domain: 'example.com', status: 'active', unreadCount: 0 },
 ];
 
+let store: ReturnType<typeof makeStore>;
+let invalidateTagsSpy: jest.SpyInstance;
+
 function renderSidebar(addresses = ADDRESSES) {
   return render(
-    <SidebarProvider>
-      <AppSidebar addresses={addresses} />
-    </SidebarProvider>,
+    <Provider store={store}>
+      <SidebarProvider>
+        <AppSidebar addresses={addresses} />
+      </SidebarProvider>
+    </Provider>,
   );
 }
 
 beforeAll(() => {
+  global.fetch = jest.fn();
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: jest.fn().mockImplementation((query: string) => ({
@@ -90,16 +84,24 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  store = makeStore();
+  // Preserve action-creator properties (.match, .type) needed by RTK Query middleware
+  const origFn = apiSlice.util.invalidateTags as unknown as Record<string, unknown>;
+  const origMatch = origFn['match'];
+  const origType = origFn['type'];
+  invalidateTagsSpy = jest.spyOn(apiSlice.util, 'invalidateTags');
+  const spyFn = apiSlice.util.invalidateTags as unknown as Record<string, unknown>;
+  spyFn['match'] = origMatch;
+  spyFn['type'] = origType;
   global.fetch = jest.fn();
   mockPathname.mockReturnValue('/');
   mockPush.mockReset();
-  mockSidebarDispatch.mockClear();
-  mockSidebarInvalidateTags.mockClear();
   wsHandler = null;
   mockSubscribe.mockClear();
 });
 
 afterEach(() => {
+  invalidateTagsSpy.mockRestore();
   jest.clearAllMocks();
 });
 
@@ -297,8 +299,7 @@ describe('AppSidebar', () => {
     await user.click(screen.getByTestId('compose-button'));
 
     await waitFor(() => {
-      expect(mockSidebarInvalidateTags).toHaveBeenCalledWith(['Draft']);
-      expect(mockSidebarDispatch).toHaveBeenCalledWith({ type: 'test/invalidate' });
+      expect(invalidateTagsSpy).toHaveBeenCalledWith(['Draft']);
     });
   });
 
@@ -318,7 +319,7 @@ describe('AppSidebar', () => {
         `/drafts/${encodeURIComponent('hello@example.com')}/existing-draft`,
       );
     });
-    expect(mockSidebarInvalidateTags).not.toHaveBeenCalled();
+    expect(invalidateTagsSpy).not.toHaveBeenCalled();
   });
 
   test('Compose button is disabled when on a draft detail route', () => {

--- a/app/__tests__/store/store.test.ts
+++ b/app/__tests__/store/store.test.ts
@@ -1,5 +1,6 @@
 import { makeStore } from '@/store';
 import { apiSlice } from '@/store/api';
+import { initCounts } from '@/store/unread-counts-slice';
 
 describe('Redux store', () => {
   it('initializes without errors', () => {
@@ -122,5 +123,166 @@ describe('apiSlice — deleteMessage optimistic update', () => {
     // Optimistic update behavior is verified in message-list.test.tsx via mock mutations.
     expect(apiSlice.endpoints.deleteMessage).toBeDefined();
     expect(typeof apiSlice.endpoints.deleteMessage.initiate).toBe('function');
+  });
+});
+
+describe('apiSlice — markReadStatus unread count side effects', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  it('decrements unread count when inbox message is marked read', async () => {
+    const store = makeStore();
+    store.dispatch(initCounts({ 'test@example.com': 5 }));
+
+    const message = { messageId: 'msg-1', subject: 'Hi', receivedAt: '2026-01-01T10:00:00Z', isRead: false, address: 'test@example.com' };
+    store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'inbox', direction: undefined },
+        { messages: [message], nextCursor: null },
+      ),
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ message: { ...message, isRead: true } }));
+
+    await store.dispatch(
+      apiSlice.endpoints.markReadStatus.initiate({
+        messageId: 'msg-1',
+        isRead: true,
+        address: 'test@example.com',
+        folder: 'inbox',
+      }),
+    );
+
+    expect((store.getState() as ReturnType<typeof store['getState']>).unreadCounts.counts['test@example.com']).toBe(4);
+  });
+
+  it('increments unread count when inbox message is marked unread', async () => {
+    const store = makeStore();
+    store.dispatch(initCounts({ 'test@example.com': 2 }));
+
+    const message = { messageId: 'msg-1', subject: 'Hi', receivedAt: '2026-01-01T10:00:00Z', isRead: true, address: 'test@example.com' };
+    store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'inbox', direction: undefined },
+        { messages: [message], nextCursor: null },
+      ),
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ message: { ...message, isRead: false } }));
+
+    await store.dispatch(
+      apiSlice.endpoints.markReadStatus.initiate({
+        messageId: 'msg-1',
+        isRead: false,
+        address: 'test@example.com',
+        folder: 'inbox',
+      }),
+    );
+
+    expect((store.getState() as ReturnType<typeof store['getState']>).unreadCounts.counts['test@example.com']).toBe(3);
+  });
+
+  it('does not change unread count for junk folder messages', async () => {
+    const store = makeStore();
+    store.dispatch(initCounts({ 'test@example.com': 3 }));
+
+    const message = { messageId: 'msg-1', subject: 'Hi', receivedAt: '2026-01-01T10:00:00Z', isRead: false, address: 'test@example.com' };
+    store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'junk', direction: undefined },
+        { messages: [message], nextCursor: null },
+      ),
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ message: { ...message, isRead: true } }));
+
+    await store.dispatch(
+      apiSlice.endpoints.markReadStatus.initiate({
+        messageId: 'msg-1',
+        isRead: true,
+        address: 'test@example.com',
+        folder: 'junk',
+      }),
+    );
+
+    expect((store.getState() as ReturnType<typeof store['getState']>).unreadCounts.counts['test@example.com']).toBe(3);
+  });
+});
+
+describe('apiSlice — moveMessage unread count side effects', () => {
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  it('decrements unread count when unread inbox message is moved out', async () => {
+    const store = makeStore();
+    store.dispatch(initCounts({ 'test@example.com': 4 }));
+
+    const message = { messageId: 'msg-1', subject: 'Hi', receivedAt: '2026-01-01T10:00:00Z', isRead: false, address: 'test@example.com' };
+    await store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'inbox', direction: undefined },
+        { messages: [message], nextCursor: null },
+      ),
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ message: { ...message, folder: 'trash' } }));
+
+    await store.dispatch(
+      apiSlice.endpoints.moveMessage.initiate({
+        messageId: 'msg-1',
+        targetFolder: 'trash',
+        fromAddress: 'test@example.com',
+        fromFolder: 'inbox',
+      }),
+    );
+
+    expect((store.getState() as ReturnType<typeof store['getState']>).unreadCounts.counts['test@example.com']).toBe(3);
+  });
+
+  it('does not decrement when moving an already-read inbox message', async () => {
+    const store = makeStore();
+    store.dispatch(initCounts({ 'test@example.com': 2 }));
+
+    const message = { messageId: 'msg-1', subject: 'Hi', receivedAt: '2026-01-01T10:00:00Z', isRead: true, address: 'test@example.com' };
+    await store.dispatch(
+      apiSlice.util.upsertQueryData(
+        'getMessages',
+        { address: 'test@example.com', folder: 'inbox', direction: undefined },
+        { messages: [message], nextCursor: null },
+      ),
+    );
+
+    (global.fetch as jest.Mock).mockResolvedValue(jsonResponse({ message: { ...message, folder: 'trash' } }));
+
+    await store.dispatch(
+      apiSlice.endpoints.moveMessage.initiate({
+        messageId: 'msg-1',
+        targetFolder: 'trash',
+        fromAddress: 'test@example.com',
+        fromFolder: 'inbox',
+      }),
+    );
+
+    expect((store.getState() as ReturnType<typeof store['getState']>).unreadCounts.counts['test@example.com']).toBe(2);
   });
 });

--- a/app/__tests__/store/unread-counts-slice.test.ts
+++ b/app/__tests__/store/unread-counts-slice.test.ts
@@ -1,0 +1,48 @@
+import unreadCountsReducer, {
+  initCounts,
+  incrementCount,
+  decrementCount,
+} from '@/store/unread-counts-slice';
+
+describe('unreadCountsSlice', () => {
+  const initial = { counts: {} };
+
+  test('initCounts replaces state with the provided map', () => {
+    const state = unreadCountsReducer(initial, initCounts({ 'a@example.com': 3, 'b@example.com': 0 }));
+    expect(state.counts).toEqual({ 'a@example.com': 3, 'b@example.com': 0 });
+  });
+
+  test('initCounts overwrites existing counts', () => {
+    const prev = unreadCountsReducer(initial, initCounts({ 'a@example.com': 5 }));
+    const state = unreadCountsReducer(prev, initCounts({ 'b@example.com': 2 }));
+    expect(state.counts).toEqual({ 'b@example.com': 2 });
+  });
+
+  test('incrementCount adds 1 to an existing address', () => {
+    const prev = unreadCountsReducer(initial, initCounts({ 'a@example.com': 2 }));
+    const state = unreadCountsReducer(prev, incrementCount('a@example.com'));
+    expect(state.counts['a@example.com']).toBe(3);
+  });
+
+  test('incrementCount starts from 0 for an unknown address', () => {
+    const state = unreadCountsReducer(initial, incrementCount('new@example.com'));
+    expect(state.counts['new@example.com']).toBe(1);
+  });
+
+  test('decrementCount subtracts 1 from an existing address', () => {
+    const prev = unreadCountsReducer(initial, initCounts({ 'a@example.com': 3 }));
+    const state = unreadCountsReducer(prev, decrementCount('a@example.com'));
+    expect(state.counts['a@example.com']).toBe(2);
+  });
+
+  test('decrementCount does not go below 0', () => {
+    const prev = unreadCountsReducer(initial, initCounts({ 'a@example.com': 0 }));
+    const state = unreadCountsReducer(prev, decrementCount('a@example.com'));
+    expect(state.counts['a@example.com']).toBe(0);
+  });
+
+  test('decrementCount on unknown address stays at 0', () => {
+    const state = unreadCountsReducer(initial, decrementCount('unknown@example.com'));
+    expect(state.counts['unknown@example.com']).toBe(0);
+  });
+});

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -3,9 +3,10 @@
 import Link, { useLinkStatus } from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
-import type { AppDispatch } from "@/store";
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "@/store";
 import { apiSlice } from "@/store/api";
+import { initCounts, incrementCount } from "@/store/unread-counts-slice";
 import {
   Sidebar,
   SidebarContent,
@@ -108,26 +109,26 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
     setSwitchingToAddress(null);
   }, [pathname]);
 
-  const [unreadCounts, setUnreadCounts] = useState<Map<string, number>>(() => {
-    const map = new Map<string, number>();
+  const unreadCountsMap = useSelector((state: RootState) => state.unreadCounts.counts);
+
+  // Initialise counts from server-rendered address props
+  useEffect(() => {
+    const initial: Record<string, number> = {};
     for (const addr of addresses) {
       if (addr.unreadCount && addr.unreadCount > 0) {
-        map.set(addr.email, addr.unreadCount);
+        initial[addr.email] = addr.unreadCount;
       }
     }
-    return map;
-  });
+    dispatch(initCounts(initial));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally run once on mount
 
-  // Increment from WS events (best-effort; overridden by RTK Query cache when inbox is open)
+  // Increment from WS new_message events
   useEffect(() => {
     return subscribe((event) => {
-      setUnreadCounts((prev) => {
-        const next = new Map(prev);
-        next.set(event.address, (next.get(event.address) ?? 0) + 1);
-        return next;
-      });
+      dispatch(incrementCount(event.address));
     });
-  }, [subscribe]);
+  }, [subscribe, dispatch]);
 
 
   async function handleCompose() {
@@ -179,7 +180,7 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
   }
 
   const activeFolder = FOLDERS.find((f) => pathname.startsWith(`/${f.key}/`))?.key ?? null;
-  const inboxUnread = selectedAddress ? (unreadCounts.get(selectedAddress) ?? 0) : 0;
+  const inboxUnread = selectedAddress ? (unreadCountsMap[selectedAddress] ?? 0) : 0;
 
   return (
     <Sidebar collapsible="icon">
@@ -226,9 +227,9 @@ export function AppSidebar({ addresses }: AppSidebarProps) {
                         : <Mail className="h-4 w-4 shrink-0 opacity-0" />
                       }
                       <span className="flex-1 truncate">{addr.email}</span>
-                      {(unreadCounts.get(addr.email) ?? 0) > 0 && (
+                      {(unreadCountsMap[addr.email] ?? 0) > 0 && (
                         <span className="ml-auto shrink-0 rounded-full bg-sidebar-primary px-1.5 py-0.5 text-xs font-medium text-sidebar-primary-foreground">
-                          {unreadCounts.get(addr.email)}
+                          {unreadCountsMap[addr.email]}
                         </span>
                       )}
                     </DropdownMenuItem>

--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -24,3 +24,25 @@ if (typeof Request === 'undefined') {
   );
   Object.assign(global, { Request: Req, Response: Res, Headers: Hdrs });
 }
+
+// The edge-runtime Request constructor requires absolute URLs. Wrap it so that
+// relative URLs (starting with '/') work in test environments by prepending
+// 'http://localhost'. This lets RTK Query's fetchBaseQuery operate with the
+// '/api' base URL without throwing a parse error.
+const _OriginalRequest = global.Request as typeof Request;
+class _TestRequest extends _OriginalRequest {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
+    if (typeof input === 'string' && input.startsWith('/')) {
+      super(`http://localhost${input}`, init);
+    } else {
+      super(input, init);
+    }
+  }
+}
+(global as unknown as Record<string, unknown>).Request = _TestRequest;
+
+// Provide a default fetch stub so RTK Query's fetchBaseQuery has a fetchFn
+// at module-load time. Individual tests override this in their own beforeEach.
+if (typeof global.fetch === 'undefined') {
+  global.fetch = jest.fn();
+}

--- a/app/store/api.ts
+++ b/app/store/api.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { incrementCount, decrementCount } from './unread-counts-slice';
 
 export type TagType = 'Message' | 'Draft' | 'Folder' | 'Thread';
 
@@ -167,8 +168,13 @@ export const apiSlice = createApi({
             },
           ),
         );
+        // Only inbox messages affect the badge count
+        const isInbox = folder === 'inbox' || folder === undefined;
         try {
           await queryFulfilled;
+          if (isInbox) {
+            dispatch(isRead ? decrementCount(address) : incrementCount(address));
+          }
         } catch {
           patch.undo();
         }
@@ -184,17 +190,24 @@ export const apiSlice = createApi({
         { messageId, fromAddress, fromFolder, fromDirection },
         { dispatch, queryFulfilled },
       ) {
+        // Check if the message being moved is unread in inbox before removing it
+        let wasUnreadInInbox = false;
         const patch = dispatch(
           apiSlice.util.updateQueryData(
             'getMessages',
             { address: fromAddress, folder: fromFolder, direction: fromDirection },
             (draft) => {
+              const msg = draft.messages.find((m) => m.messageId === messageId);
+              if (msg && !msg.isRead && (fromFolder === 'inbox' || fromFolder === undefined)) {
+                wasUnreadInInbox = true;
+              }
               draft.messages = draft.messages.filter((m) => m.messageId !== messageId);
             },
           ),
         );
         try {
           await queryFulfilled;
+          if (wasUnreadInInbox) dispatch(decrementCount(fromAddress));
         } catch {
           patch.undo();
         }

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { apiSlice } from './api';
+import unreadCountsReducer from './unread-counts-slice';
 
 export const makeStore = () =>
   configureStore({
     reducer: {
       [apiSlice.reducerPath]: apiSlice.reducer,
+      unreadCounts: unreadCountsReducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(apiSlice.middleware),

--- a/app/store/unread-counts-slice.ts
+++ b/app/store/unread-counts-slice.ts
@@ -1,0 +1,25 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface UnreadCountsState {
+  counts: Record<string, number>;
+}
+
+const unreadCountsSlice = createSlice({
+  name: 'unreadCounts',
+  initialState: { counts: {} } as UnreadCountsState,
+  reducers: {
+    initCounts(_state, action: PayloadAction<Record<string, number>>) {
+      return { counts: action.payload };
+    },
+    incrementCount(state, action: PayloadAction<string>) {
+      state.counts[action.payload] = (state.counts[action.payload] ?? 0) + 1;
+    },
+    decrementCount(state, action: PayloadAction<string>) {
+      const cur = state.counts[action.payload] ?? 0;
+      state.counts[action.payload] = Math.max(0, cur - 1);
+    },
+  },
+});
+
+export const { initCounts, incrementCount, decrementCount } = unreadCountsSlice.actions;
+export default unreadCountsSlice.reducer;


### PR DESCRIPTION
…moved (#233)

- Add unreadCounts Redux slice with initCounts, incrementCount, decrementCount actions
- Wire sidebar to Redux unread counts instead of local Map state
- Dispatch decrementCount/incrementCount from markReadStatus.onQueryStarted on success
- Dispatch decrementCount from moveMessage.onQueryStarted when moving unread inbox message
- Add tests for unreadCounts slice and RTK side-effect dispatches

closes #233