### PR TITLE
[feat]: eliminate SSR loopback fetch and cache static assets in Cloud…

### DIFF
--- a/app/__tests__/lib/auth/require-auth.test.ts
+++ b/app/__tests__/lib/auth/require-auth.test.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from 'next/server';
-import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+import { requireAuth, verifyToken, AuthError } from '@/lib/auth/require-auth';
 import { clearJwksCache } from '@/lib/auth/jwks-cache';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -165,5 +165,32 @@ describe('requireAuth', () => {
       const req = makeRequest({ authHeader: 'Bearer some.token' });
       await expect(requireAuth(req)).rejects.toMatchObject({ status: 500 });
     });
+  });
+});
+
+describe('verifyToken', () => {
+  test('returns decoded claims for a valid token string', async () => {
+    const claims = { sub: 'user-123', email: 'user@example.com' };
+    mockJwtVerify.mockResolvedValueOnce({ payload: claims });
+
+    const result = await verifyToken('valid.jwt.token');
+
+    expect(result).toEqual(claims);
+    expect(mockJwtVerify).toHaveBeenCalledWith('valid.jwt.token', FAKE_JWKS, expect.any(Object));
+  });
+
+  test('throws AuthError 401 for an invalid token string', async () => {
+    mockJwtVerify.mockRejectedValueOnce(new Error('JWTExpired'));
+
+    await expect(verifyToken('expired.token')).rejects.toMatchObject({
+      status: 401,
+      message: 'Invalid or expired token',
+    });
+  });
+
+  test('throws AuthError 500 when COGNITO_USER_POOL_ID is missing', async () => {
+    delete process.env.COGNITO_USER_POOL_ID;
+
+    await expect(verifyToken('some.token')).rejects.toMatchObject({ status: 500 });
   });
 });

--- a/app/__tests__/lib/data/addresses.test.ts
+++ b/app/__tests__/lib/data/addresses.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment node
+ */
+
+const mockDynamoSend = jest.fn();
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn().mockImplementation(() => ({ send: mockDynamoSend })) },
+  ScanCommand: jest.fn((p: unknown) => p),
+  QueryCommand: jest.fn((p: unknown) => p),
+}));
+
+process.env.ADDRESSES_TABLE = 'hermes-addresses';
+process.env.MESSAGES_TABLE = 'hermes-messages';
+
+import { queryAddresses } from '@/lib/data/addresses';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('queryAddresses', () => {
+  function setupMock(addresses: unknown[], unreadCount = 0) {
+    mockDynamoSend.mockImplementation((cmd: Record<string, unknown>) => {
+      if ('IndexName' in cmd) return Promise.resolve({ Count: unreadCount });
+      return Promise.resolve({ Items: addresses });
+    });
+  }
+
+  test('returns active addresses with unread counts', async () => {
+    setupMock([{ email: 'a@example.com', domain: 'example.com', status: 'active' }], 5);
+
+    const result = await queryAddresses();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].email).toBe('a@example.com');
+    expect(result[0].unreadCount).toBe(5);
+  });
+
+  test('returns empty array when no addresses exist', async () => {
+    setupMock([]);
+
+    const result = await queryAddresses();
+    expect(result).toEqual([]);
+  });
+
+  test('sets unreadCount to 0 for non-active addresses without querying messages table', async () => {
+    setupMock([{ email: 'x@example.com', domain: 'example.com', status: 'suspended' }]);
+
+    const result = await queryAddresses();
+
+    expect(result[0].unreadCount).toBe(0);
+    // ScanCommand fired once; QueryCommand must not have been called
+    const calls = mockDynamoSend.mock.calls as [Record<string, unknown>][];
+    expect(calls.every(([cmd]) => !('IndexName' in cmd))).toBe(true);
+  });
+
+  test('fetches unread counts in parallel for multiple active addresses', async () => {
+    setupMock([
+      { email: 'a@example.com', domain: 'example.com', status: 'active' },
+      { email: 'b@example.com', domain: 'example.com', status: 'active' },
+    ], 2);
+
+    const result = await queryAddresses();
+
+    expect(result).toHaveLength(2);
+    expect(result.every((a) => a.unreadCount === 2)).toBe(true);
+  });
+
+  test('falls back to unreadCount 0 when messages query fails', async () => {
+    mockDynamoSend.mockImplementation((cmd: Record<string, unknown>) => {
+      if ('IndexName' in cmd) return Promise.reject(new Error('DynamoDB error'));
+      return Promise.resolve({ Items: [{ email: 'a@example.com', domain: 'example.com', status: 'active' }] });
+    });
+
+    const result = await queryAddresses();
+    expect(result[0].unreadCount).toBe(0);
+  });
+
+  test('unread count query filters to inbox folder only', async () => {
+    setupMock([{ email: 'a@example.com', domain: 'example.com', status: 'active' }], 3);
+
+    await queryAddresses();
+
+    const queryArg = (mockDynamoSend.mock.calls as [Record<string, unknown>][])
+      .map(([cmd]) => cmd)
+      .find((cmd) => 'IndexName' in cmd);
+
+    expect(queryArg).toMatchObject({
+      FilterExpression: expect.stringContaining('attribute_not_exists(#folder)'),
+      ExpressionAttributeNames: expect.objectContaining({ '#folder': 'folder' }),
+      ExpressionAttributeValues: expect.objectContaining({ ':inbox': 'inbox' }),
+    });
+  });
+
+  test('scan filters out soft-deleted addresses via FilterExpression', async () => {
+    setupMock([]);
+
+    await queryAddresses();
+
+    const scanArg = (mockDynamoSend.mock.calls[0] as [Record<string, unknown>])[0];
+    expect(scanArg).toMatchObject({
+      FilterExpression: expect.stringContaining('<>'),
+      ExpressionAttributeValues: expect.objectContaining({ ':deleted': 'deleted' }),
+    });
+  });
+});

--- a/app/app/(app)/layout.tsx
+++ b/app/app/(app)/layout.tsx
@@ -5,30 +5,8 @@ import { ConditionalLayout } from '@/components/layout/conditional-layout';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { WebSocketProvider } from '@/components/ws-context';
 import { SIDEBAR_STATE_COOKIE } from '@/lib/preferences';
-
-interface Address {
-  email: string;
-  domain: string;
-  status: string;
-  unreadCount?: number;
-}
-
-async function getAddresses(token: string): Promise<Address[]> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
-  const res = await fetch(`${baseUrl}/api/addresses`, {
-    headers: { Cookie: `access_token=${token}` },
-    cache: 'no-store',
-  });
-
-  if (res.status === 401) {
-    redirect('/login');
-  }
-
-  if (!res.ok) return [];
-
-  const data = await res.json();
-  return data.addresses ?? [];
-}
+import { verifyToken } from '@/lib/auth/require-auth';
+import { queryAddresses } from '@/lib/data/addresses';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();
@@ -38,7 +16,13 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     redirect('/login');
   }
 
-  const addresses = await getAddresses(token);
+  try {
+    await verifyToken(token);
+  } catch {
+    redirect('/login');
+  }
+
+  const addresses = await queryAddresses();
   const wsEndpoint = process.env.NEXT_PUBLIC_WEBSOCKET_ENDPOINT ?? '';
 
   const sidebarStateCookie = cookieStore.get(SIDEBAR_STATE_COOKIE)?.value;

--- a/app/app/api/addresses/route.ts
+++ b/app/app/api/addresses/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SESClient, ListIdentitiesCommand, CreateReceiptRuleCommand } from '@aws-sdk/client-ses';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, ScanCommand, PutCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { requireAuth, AuthError } from '@/lib/auth/require-auth';
+import { queryAddresses } from '@/lib/data/addresses';
 
 function getSes() {
   return new SESClient({ region: process.env.AWS_REGION ?? 'us-east-1' });
@@ -22,38 +23,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 
-  const dynamo = getDynamo();
-  const result = await dynamo.send(new ScanCommand({
-    TableName: process.env.ADDRESSES_TABLE!,
-    FilterExpression: '#s <> :deleted',
-    ExpressionAttributeNames: { '#s': 'status' },
-    ExpressionAttributeValues: { ':deleted': 'deleted' },
-  }));
-
-  const addresses = result.Items ?? [];
-
-  // Fetch unread counts for all active addresses in parallel.
-  const withCounts = await Promise.all(
-    addresses.map(async (addr) => {
-      if (addr.status !== 'active') return { ...addr, unreadCount: 0 };
-      try {
-        const unread = await dynamo.send(new QueryCommand({
-          TableName: process.env.MESSAGES_TABLE!,
-          IndexName: 'address-receivedAt-index',
-          KeyConditionExpression: 'address = :addr',
-          FilterExpression: 'isRead = :false AND direction = :dir AND (#folder = :inbox OR attribute_not_exists(#folder))',
-          ExpressionAttributeNames: { '#folder': 'folder' },
-          ExpressionAttributeValues: { ':addr': addr.email, ':false': false, ':dir': 'inbound', ':inbox': 'inbox' },
-          Select: 'COUNT',
-        }));
-        return { ...addr, unreadCount: unread.Count ?? 0 };
-      } catch {
-        return { ...addr, unreadCount: 0 };
-      }
-    }),
-  );
-
-  return NextResponse.json({ addresses: withCounts });
+  const addresses = await queryAddresses();
+  return NextResponse.json({ addresses });
 }
 
 export async function POST(req: NextRequest) {

--- a/app/lib/auth/require-auth.ts
+++ b/app/lib/auth/require-auth.ts
@@ -18,7 +18,7 @@ export interface CognitoClaims extends JWTPayload {
   token_use?: string;
 }
 
-export async function requireAuth(req: NextRequest): Promise<CognitoClaims> {
+export async function verifyToken(token: string): Promise<CognitoClaims> {
   const userPoolId = process.env.COGNITO_USER_POOL_ID;
   const region = process.env.AWS_REGION ?? 'us-east-1';
 
@@ -26,6 +26,18 @@ export async function requireAuth(req: NextRequest): Promise<CognitoClaims> {
     throw new AuthError('Server misconfiguration: COGNITO_USER_POOL_ID not set', 500);
   }
 
+  const issuer = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
+  const jwks = getJwks(userPoolId, region);
+
+  try {
+    const { payload } = await jwtVerify(token, jwks, { issuer });
+    return payload as CognitoClaims;
+  } catch {
+    throw new AuthError('Invalid or expired token');
+  }
+}
+
+export async function requireAuth(req: NextRequest): Promise<CognitoClaims> {
   const authHeader = req.headers.get('authorization') ?? req.headers.get('Authorization');
   let token: string | undefined;
 
@@ -40,16 +52,5 @@ export async function requireAuth(req: NextRequest): Promise<CognitoClaims> {
     throw new AuthError('Missing authentication token');
   }
 
-  const issuer = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
-  const jwks = getJwks(userPoolId, region);
-
-  try {
-    const { payload } = await jwtVerify(token, jwks, {
-      issuer,
-    });
-
-    return payload as CognitoClaims;
-  } catch {
-    throw new AuthError('Invalid or expired token');
-  }
+  return verifyToken(token);
 }

--- a/app/lib/data/addresses.ts
+++ b/app/lib/data/addresses.ts
@@ -1,0 +1,47 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, ScanCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+export interface Address {
+  email: string;
+  domain: string;
+  status: string;
+  unreadCount: number;
+  [key: string]: unknown;
+}
+
+function getDynamo() {
+  return DynamoDBDocumentClient.from(new DynamoDBClient({ region: process.env.AWS_REGION ?? 'us-east-1' }));
+}
+
+export async function queryAddresses(): Promise<Address[]> {
+  const dynamo = getDynamo();
+
+  const result = await dynamo.send(new ScanCommand({
+    TableName: process.env.ADDRESSES_TABLE!,
+    FilterExpression: '#s <> :deleted',
+    ExpressionAttributeNames: { '#s': 'status' },
+    ExpressionAttributeValues: { ':deleted': 'deleted' },
+  }));
+
+  const items = result.Items ?? [];
+
+  return Promise.all(
+    items.map(async (addr) => {
+      if (addr.status !== 'active') return { ...addr, unreadCount: 0 } as Address;
+      try {
+        const unread = await dynamo.send(new QueryCommand({
+          TableName: process.env.MESSAGES_TABLE!,
+          IndexName: 'address-receivedAt-index',
+          KeyConditionExpression: 'address = :addr',
+          FilterExpression: 'isRead = :false AND direction = :dir AND (#folder = :inbox OR attribute_not_exists(#folder))',
+          ExpressionAttributeNames: { '#folder': 'folder' },
+          ExpressionAttributeValues: { ':addr': addr.email, ':false': false, ':dir': 'inbound', ':inbox': 'inbox' },
+          Select: 'COUNT',
+        }));
+        return { ...addr, unreadCount: unread.Count ?? 0 } as Address;
+      } catch {
+        return { ...addr, unreadCount: 0 } as Address;
+      }
+    }),
+  );
+}

--- a/infra/lib/hermes-app-stack.ts
+++ b/infra/lib/hermes-app-stack.ts
@@ -155,6 +155,8 @@ export class HermesAppStack extends cdk.Stack {
       authType: lambda.FunctionUrlAuthType.NONE,
     });
 
+    const staticAssetOrigin = new origins.FunctionUrlOrigin(functionUrl);
+
     const distribution = new cloudfront.Distribution(this, 'AppDistribution', {
       defaultBehavior: {
         origin: new origins.FunctionUrlOrigin(functionUrl),
@@ -162,6 +164,17 @@ export class HermesAppStack extends cdk.Stack {
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+      },
+      // Next.js content-hashes all /_next/static/* assets so they are safe to
+      // cache at the edge indefinitely. This avoids hitting Lambda for every JS
+      // chunk, font, and icon on every page load.
+      additionalBehaviors: {
+        '/_next/static/*': {
+          origin: staticAssetOrigin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD,
+        },
       },
       priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
       ...(props.domainName && props.certificate ? {


### PR DESCRIPTION
…Front (#235)

- Extract verifyToken(token) from requireAuth so Server Components can validate JWTs without a NextRequest object
- Extract queryAddresses() into lib/data/addresses.ts so the DynamoDB logic is callable in-process from the layout
- Replace the HTTP loopback fetch in (app)/layout.tsx with direct calls to verifyToken + queryAddresses, cutting one full Lambda round-trip on every page load
- Add additionalBehaviors in CloudFront for /_next/static/* with CACHING_OPTIMIZED so content-hashed static assets are served from the edge instead of hitting Lambda
- Add tests for queryAddresses and verifyToken

closes #235